### PR TITLE
lua-dest: Added deinit function for lua destination.

### DIFF
--- a/modules/lua/lua-dest.h
+++ b/modules/lua/lua-dest.h
@@ -36,6 +36,7 @@ typedef struct _LuaDestDriver
   gchar *filename;
   gchar *init_func_name;
   gchar *queue_func_name;
+  gchar *deinit_func_name;
   LogTemplate *template;
   LogTemplateOptions template_options;
   gint mode;
@@ -44,6 +45,7 @@ typedef struct _LuaDestDriver
 LogDriver *lua_dd_new();
 void lua_dd_set_init_func(LogDriver *d, gchar *init_func_name);
 void lua_dd_set_queue_func(LogDriver *d, gchar *queue_func_name);
+void lua_dd_set_deinit_func(LogDriver *d, gchar *deinit_func_name);
 void lua_dd_set_filename(LogDriver *d, gchar *filename);
 void lua_dd_set_template(LogDriver *d, LogTemplate *template);
 void lua_dd_set_mode(LogDriver *d, gchar *mode);

--- a/modules/lua/lua-grammar.ym
+++ b/modules/lua/lua-grammar.ym
@@ -47,6 +47,7 @@
 %token KW_SCRIPT
 %token KW_INIT_FUNC
 %token KW_QUEUE_FUNC
+%token KW_DEINIT_FUNC
 %token KW_LUA_DEST_MODE
 
 %%
@@ -82,6 +83,11 @@ lua_option
         | KW_QUEUE_FUNC '(' string ')'
           {
             lua_dd_set_queue_func(last_driver, $3);
+            free($3);
+          }
+        | KW_DEINIT_FUNC '(' string ')'
+          {
+            lua_dd_set_deinit_func(last_driver, $3);
             free($3);
           }
         | KW_LUA_DEST_MODE '(' string ')'

--- a/modules/lua/lua-parser.c
+++ b/modules/lua/lua-parser.c
@@ -33,6 +33,7 @@ static CfgLexerKeyword lua_keywords[] = {
   { "script",                   KW_SCRIPT },
   { "init_func",                KW_INIT_FUNC },
   { "queue_func",               KW_QUEUE_FUNC },
+  { "deinit_func",              KW_DEINIT_FUNC },
   { "mode",                     KW_LUA_DEST_MODE },
   { NULL }
 };


### PR DESCRIPTION
Added new deinit-func() parameter, in which we can specify a
function name which is called during destination driver deinitialization.
