### PR TITLE
lua: Added logging utility functions.

### DIFF
--- a/modules/lua/lua-dest.c
+++ b/modules/lua/lua-dest.c
@@ -163,6 +163,8 @@ lua_dd_init(LogPipe *s)
   lua_register_message(self->state);
   lua_register_template_class(self->state);
 
+  lua_register_utility_functions(self->state);
+
   cfg = log_pipe_get_config(s);
 
   lua_dd_set_config_variable(self->state, cfg);

--- a/modules/lua/lua-utils.c
+++ b/modules/lua/lua-utils.c
@@ -23,6 +23,7 @@
 
 #include "lua-utils.h"
 #include <lauxlib.h>
+#include "messages.h"
 
 static void *
 lua_get_pointer_from_userdata(void *udata)
@@ -104,3 +105,50 @@ lua_get_config_from_current_state(lua_State *state)
     lua_pop(state, 1);
     return result;
 }
+
+static int
+lua_msg_debug(lua_State *state)
+{
+  const char *message = lua_tostring(state, -1);
+  msg_debug(message, NULL);
+  return 0;
+};
+
+static int
+lua_msg_error(lua_State *state)
+{
+  const char *message = lua_tostring(state, -1);
+  msg_error(message, NULL);
+  return 0;
+};
+
+static int
+lua_msg_info(lua_State *state)
+{
+  const char *message = lua_tostring(state, -1);
+  msg_info(message, NULL);
+  return 0;
+};
+
+static int
+lua_msg_verbose(lua_State *state)
+{
+  const char *message = lua_tostring(state, -1);
+  msg_verbose(message, NULL);
+  return 0;
+};
+
+static const struct luaL_Reg utility_functions [] =
+{
+  {"debug", lua_msg_debug},
+  {"error", lua_msg_error},
+  {"verbose", lua_msg_verbose},
+  {"info", lua_msg_info},
+
+  {NULL, NULL}
+};
+
+void lua_register_utility_functions(lua_State *state)
+{
+  luaL_openlib(state, "syslogng", utility_functions, 0);
+};

--- a/modules/lua/lua-utils.h
+++ b/modules/lua/lua-utils.h
@@ -31,5 +31,6 @@ void *lua_check_and_convert_userdata(lua_State *state, int index, const char *ty
 int lua_create_userdata_from_pointer(lua_State *state, void *data, const char *type);
 gboolean lua_check_existence_of_global_variable(lua_State *state, const char *variable_name);
 GlobalConfig *lua_get_config_from_current_state(lua_State *state);
+void lua_register_utility_functions(lua_State *state);
 
 #endif

--- a/modules/monitor-source/monitor-source.c
+++ b/modules/monitor-source/monitor-source.c
@@ -215,6 +215,8 @@ monitor_source_init (LogPipe *s)
       return FALSE;
     }
 
+  lua_register_utility_functions(self->state);
+
   if (!lua_check_existence_of_global_variable(self->state, self->options->monitor_func_name))
     {
       msg_error("Monitor function for monitor source cannot be found!", 


### PR DESCRIPTION
There are four new functions callable from monitor source and lua destination.
They are syslogng.debug, syslogng.error, syslogng.verbose, syslogng.info.
Through them it is possible to create syslog-ng log messages. All of them
requires one string (the message) as a parameter.

Signed-off-by: Tusa Viktor tusavik@gmail.com
