### PR TITLE
lua: Add support for setting global variables

### DIFF
--- a/modules/lua/elasticsearch.conf
+++ b/modules/lua/elasticsearch.conf
@@ -10,6 +10,13 @@ destination d_lua {
     template("$(format_json --scope nv_pairs --key PROGRAM --pair @timestamp=\"${R_ISODATE}\" --pair @message=\"${MSG}\")")
     init-func("elastic_init")
     queue-func("elastic_queue")
+    globals(
+      es_batch_size(int(100))
+      es_host("localhost")
+      es_port("9200")
+      es_index("syslog-ng")
+      es_type("message")
+    )
   );
 };
 

--- a/modules/lua/elasticsearch.lua
+++ b/modules/lua/elasticsearch.lua
@@ -26,22 +26,18 @@
 --
 -- Use this table to configure the destination
 --
-config = {
-   batch_size = 100,
-   es = {
-      host = "localhost",
-      port = "9200",
-      index = "syslog-ng",
-      type = "message"
-   }
-}
+es_batch_size = 100
+es_host = "localhost"
+es_port = "9200"
+es_index = "syslog-ng"
+es_type = "message"
 
 function elastic_request(config, ep, req)
    req = req .. "\n"
    local request_len = tostring(#req)
 
    local result, respcode, respheaders, respstatus = http.request {
-      url = "http://" .. config.es.host .. ":" .. config.es.port .. ep .. "/_bulk",
+      url = "http://" .. es_host .. ":" .. es_port .. ep .. "/_bulk",
       source = ltn12.source.string(req),
       headers = {
          ["Content-Type"] = "application/json",
@@ -57,11 +53,11 @@ function elastic_queue(msg)
    request = request .. '\n{"create":null}\n' .. msg
    msgcount = msgcount + 1
 
-  if (msgcount % config.batch_size) == 0 then
+  if (msgcount % es_batch_size) == 0 then
       request_len = tostring(#request)
       -- print ("Sending msgs, bytes=" .. request_len .. "; count="..tostring(msgcount))
 
-      elastic_request(config, "/" .. config.es.index .. "/" .. config.es.type,
+      elastic_request(config, "/" .. es_index .. "/" .. es_type,
                       request)
       request = ""
   end

--- a/modules/lua/lua-dest.h
+++ b/modules/lua/lua-dest.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2013, 2014 Viktor Tusa <tusa@balabit.hu>
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -26,6 +27,7 @@
 
 #include "driver.h"
 #include "logwriter.h"
+#include "value-pairs.h"
 #include <lua.h>
 
 typedef struct _LuaDestDriver
@@ -40,6 +42,7 @@ typedef struct _LuaDestDriver
   LogTemplate *template;
   LogTemplateOptions template_options;
   gint mode;
+  ValuePairs *globals;
 } LuaDestDriver;
 
 LogDriver *lua_dd_new();
@@ -49,6 +52,7 @@ void lua_dd_set_deinit_func(LogDriver *d, gchar *deinit_func_name);
 void lua_dd_set_filename(LogDriver *d, gchar *filename);
 void lua_dd_set_template(LogDriver *d, LogTemplate *template);
 void lua_dd_set_mode(LogDriver *d, gchar *mode);
+void lua_dd_set_globals(LogDriver *d, ValuePairs *vp);
 
 LogTemplateOptions *lua_dd_get_template_options(LogDriver *d);
 

--- a/modules/lua/lua-grammar.ym
+++ b/modules/lua/lua-grammar.ym
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2013, 2014 Viktor Tusa <tusa@balabit.hu>
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -25,6 +26,8 @@
 
 #include "lua-parser.h"
 #include "lua-dest.h"
+#include "value-pairs.h"
+#include "vptransform.h"
 
 }
 
@@ -49,6 +52,7 @@
 %token KW_QUEUE_FUNC
 %token KW_DEINIT_FUNC
 %token KW_LUA_DEST_MODE
+%token KW_GLOBALS
 
 %%
 
@@ -95,8 +99,30 @@ lua_option
             lua_dd_set_mode(last_driver, $3);
             free($3);
           }
+        | KW_GLOBALS
+          {
+            last_value_pairs = value_pairs_new();
+          }
+          '(' lua_globals ')'
+          {
+            lua_dd_set_globals(last_driver, last_value_pairs);
+          }
         | dest_driver_option
         | { last_template_options = lua_dd_get_template_options(last_driver); } template_option
+        ;
+
+lua_globals
+        : lua_global lua_globals
+        |
+        ;
+
+lua_global
+        : LL_IDENTIFIER '(' template_content ')'
+          {
+            value_pairs_add_pair(last_value_pairs, $1,  $3);
+            free($1);
+          }
+        | vp_option
         ;
 
 /* INCLUDE_RULES */

--- a/modules/lua/lua-parser.c
+++ b/modules/lua/lua-parser.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013, 2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 2013, 2014 Viktor Tusa <tusa@balabit.hu>
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -35,6 +36,7 @@ static CfgLexerKeyword lua_keywords[] = {
   { "queue_func",               KW_QUEUE_FUNC },
   { "deinit_func",              KW_DEINIT_FUNC },
   { "mode",                     KW_LUA_DEST_MODE },
+  { "globals",                  KW_GLOBALS },
   { NULL }
 };
 


### PR DESCRIPTION
This adds a global() option to the lua destination, where one can list name-value pairs, which will be injected into the lua state upon startup, shortly after the script is loaded. Currently, it supports only strings and 32-bit integers.

An usage example is included in the elasticsearch example.

It (ab)uses value-pairs to collect the global options. It would likely be better to use a GTree or hashtable instead, as we do not need the whole value-pairs infrastructure. But once the interface is agreed upon, we can easily change the code behind it.
