### PR TITLE
perl: New module implementing a Perl destination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo ./add-release.sh syslog-ng-3.5
   - sudo apt-get update -qq
   - sudo apt-get install -qq aptitude
-  - sudo aptitude install -q -y pkg-config flex bison liblua5.2-dev libmongo-client-dev syslog-ng-dev
+  - sudo aptitude install -q -y pkg-config flex bison liblua5.2-dev libmongo-client-dev syslog-ng-dev libperl-dev
 before_script:
   - autoreconf -i
 script:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Contents
 
    [sng:lua]: https://github.com/balabit/syslog-ng-incubator/tree/master/modules/lua/
 
+ * [Perl destination][sng:perl]: This destination allows one to write
+   destination plugins in Perl.
+
+   [sng:perl]: https://github.com/balabit/syslog-ng-incubator/tree/master/modules/perl/
+
  * [Trigger source][sng:trigger]: A very simple example source that
    periodically generates a message. Useful mostly for debugging
    purposes.
@@ -80,11 +85,13 @@ Installing the modules and tools follows the usual autotools way:
 
 Of course, one will need all the dependencies ([syslog-ng][sng],
 bison, flex, [riemann-c-client][lrc], [libmongo-client][lmc],
-[lua][lua]; of which the latter three are optional) installed too.
+[lua][lua], [perl][perl]; of which the latter four are optional)
+installed too.
 
  [lrc]: https://github.com/algernon/riemann-c-client
  [lmc]: https://github.com/algernon/libmongo-client
  [lua]: http://www.lua.org/
+ [perl]: http://www.perl.org/
 
 License
 -------

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,23 @@ fi
 PKG_CHECK_MODULES(LUA, $lua_mod >= $LUA_MIN_VERSION,enable_lua="yes",enable_lua="no")
 
 dnl ***************************************************************************
+dnl Perl checks
+dnl ***************************************************************************
+enable_perl="no"
+AC_CHECK_PROG(PERL, perl, perl)
+if test "x$PERL" != "x"; then
+  AC_MSG_CHECKING(for perl module ExtUtils::Embed)
+  $PERL -e "use ExtUtils::Embed; exit" >/dev/null 2>&1
+  if test $? -ne 0; then
+    AC_MSG_RESULT(no)
+  else
+    AC_MSG_RESULT(ok)
+    enable_perl="yes"
+  fi
+fi
+
+
+dnl ***************************************************************************
 dnl misc features to be enabled
 dnl ***************************************************************************
 
@@ -130,6 +147,7 @@ AC_SUBST(moduledir)
 AM_CONDITIONAL(ENABLE_LOGMONGOURCE, [test "$enable_logmongource" != "no"])
 AM_CONDITIONAL(ENABLE_RIEMANN, [test "$enable_riemann" != "no"])
 AM_CONDITIONAL(ENABLE_LUA, [test "$enable_lua" != "no"])
+AM_CONDITIONAL(ENABLE_PERL, [test "$enable_perl" != "no"])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
@@ -143,6 +161,7 @@ echo "  graphite             yes"
 echo "  logmongource:        ${enable_logmongource:-yes}"
 echo "  lua:                 ${enable_lua:-yes} ${lua_mod:+($lua_mod)}"
 echo "  monitor-source:      ${enable_lua:-yes} ${lua_mod:+($lua_mod)}"
+echo "  perl:                ${enable_perl:-yes}"
 echo "  riemann:             ${enable_riemann:-yes}"
 echo "  rss                  yes"
 echo "  trigger-source       yes"

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -6,3 +6,4 @@ include modules/rss/Makefile.am
 include modules/lua/Makefile.am
 include modules/graphite/Makefile.am
 include modules/getent/Makefile.am
+include modules/perl/Makefile.am

--- a/modules/perl/Makefile.am
+++ b/modules/perl/Makefile.am
@@ -1,0 +1,48 @@
+if ENABLE_PERL
+
+module_LTLIBRARIES				+= modules/perl/libmod-perl.la
+
+PERL_CFLAGS	= $(shell perl -MExtUtils::Embed -e ccopts)
+PERL_LDADD	= $(shell perl -MExtUtils::Embed -e ldopts)
+
+modules_perl_libmod_perl_la_CFLAGS		= \
+	$(PERL_CFLAGS)				  \
+	$(SYSLOG_NG_CFLAGS)			  \
+	$(EVENTLOG_CFLAGS)			  \
+	$(IVYKIS_CFLAGS)			  \
+	-I$(top_srcdir)/modules/perl		  \
+	-I$(top_builddir)/modules/perl
+
+modules_perl_libmod_perl_la_LIBADD		= \
+	$(EVENTLOG_LIBS)			  \
+	$(SYSLOG_NG_LIBS)			  \
+	$(IVYKIS_LIBS)
+
+modules_perl_libmod_perl_la_SOURCES		= \
+	modules/perl/perl-plugin.c		  \
+	modules/perl/perl-grammar.y		  \
+	modules/perl/perl-dest.c		  \
+	modules/perl/perl-dest.h		  \
+	modules/perl/perl-parser.c		  \
+	modules/perl/perl-parser.h
+
+modules_perl_libmod_perl_la_LDFLAGS		 = \
+	-avoid-version -module -no-undefined	   \
+	$(PERL_LDADD)
+
+BUILT_SOURCES					+= \
+	modules/perl/perl-grammar.y		   \
+	modules/perl/perl-grammar.c		   \
+	modules/perl/perl-grammar.h
+
+modules/perl mod-perl: modules/perl/libmod-perl.la
+else
+modules/perl mod-perl:
+endif
+
+EXTRA_DIST					+= \
+	modules/perl/perl-grammar.ym		   \
+	modules/perl/perl-example.conf		   \
+	modules/perl/perl-example.pl
+
+.PHONY: modules/perl mod-perl

--- a/modules/perl/perl-dest.c
+++ b/modules/perl/perl-dest.c
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "perl-dest.h"
+#include "logthrdestdrv.h"
+#include "stats.h"
+#include "misc.h"
+
+#include <EXTERN.h>
+#include <perl.h>
+
+#ifndef SCS_PERL
+#define SCS_PERL 0
+#endif
+
+typedef struct
+{
+  LogThrDestDriver super;
+
+  gchar *filename;
+  gchar *init_func_name;
+  gchar *queue_func_name;
+  gchar *deinit_func_name;
+  LogTemplateOptions template_options;
+  ValuePairs *vp;
+
+  gint32 seq_num;
+
+  PerlInterpreter *perl;
+} PerlDestDriver;
+
+/** Setters & config glue **/
+
+void
+perl_dd_set_init_func(LogDriver *d, gchar *init_func_name)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  g_free(self->init_func_name);
+  self->init_func_name = g_strdup(init_func_name);
+}
+
+void
+perl_dd_set_queue_func(LogDriver *d, gchar *queue_func_name)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  g_free(self->queue_func_name);
+  self->queue_func_name = g_strdup(queue_func_name);
+}
+
+void
+perl_dd_set_deinit_func(LogDriver *d, gchar *deinit_func_name)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  g_free(self->deinit_func_name);
+  self->deinit_func_name = g_strdup(deinit_func_name);
+}
+
+void
+perl_dd_set_filename(LogDriver *d, gchar *filename)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  g_free(self->filename);
+  self->filename = g_strdup(filename);
+}
+
+void
+perl_dd_set_value_pairs(LogDriver *d, ValuePairs *vp)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  if (self->vp)
+    value_pairs_free(self->vp);
+  self->vp = vp;
+}
+
+LogTemplateOptions *
+perl_dd_get_template_options(LogDriver *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  return &self->template_options;
+}
+
+/** Helpers for stats & persist_name formatting **/
+
+static gchar *
+perl_dd_format_stats_instance(LogThrDestDriver *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+  static gchar persist_name[1024];
+
+  g_snprintf(persist_name, sizeof(persist_name),
+             "perl,%s,%s,%s,%s",
+             self->filename,
+             self->init_func_name,
+             self->queue_func_name,
+             self->deinit_func_name);
+  return persist_name;
+}
+
+static gchar *
+perl_dd_format_persist_name(LogThrDestDriver *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+  static gchar persist_name[1024];
+
+  g_snprintf(persist_name, sizeof(persist_name),
+             "perl(%s,%s,%s,%s)",
+             self->filename,
+             self->init_func_name,
+             self->queue_func_name,
+             self->deinit_func_name);
+  return persist_name;
+}
+
+/** Perl calling helpers **/
+
+static gboolean
+_perl_call_func_noargs(PerlDestDriver *self, const gchar *fname)
+{
+  PerlInterpreter *my_perl = self->perl;
+  char *args[] = { NULL };
+  dSP;
+  int count, r = 0;
+
+  ENTER;
+  SAVETMPS;
+
+  count = call_argv(fname, G_SCALAR | G_EVAL | G_NOARGS, args);
+
+  SPAGAIN;
+
+  if (SvTRUE(ERRSV))
+    {
+      msg_error("Error while calling a Perl function",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("script", self->filename),
+                evt_tag_str("function", fname),
+                evt_tag_str("error-message", SvPV_nolen(ERRSV)),
+                NULL);
+      (void) POPs;
+      goto exit;
+    }
+
+  if (count != 1)
+    {
+      msg_error("Too many values returned by a Perl function",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("script", self->filename),
+                evt_tag_str("function", fname),
+                evt_tag_int("returned-values", count),
+                evt_tag_int("expected-values", 1),
+                NULL);
+      return FALSE;
+    }
+
+  r = POPi;
+
+ exit:
+  PUTBACK;
+  FREETMPS;
+  LEAVE;
+
+  return (r != 0);
+}
+
+static void xs_init (pTHX);
+
+EXTERN_C void boot_DynaLoader (pTHX_ CV* cv);
+
+EXTERN_C void
+xs_init(pTHX)
+{
+  char *file = __FILE__;
+  dXSUB_SYS;
+
+  /* DynaLoader is a special case */
+  newXS("DynaLoader::boot_DynaLoader", boot_DynaLoader, file);
+}
+
+/** Value pairs **/
+
+static gboolean
+perl_worker_vp_add_one(const gchar *name,
+                       TypeHint type, const gchar *value,
+                       gpointer user_data)
+{
+  PerlInterpreter *my_perl = (PerlInterpreter *)((gpointer *)user_data)[0];
+  HV *kvmap = (HV *)((gpointer *)user_data)[1];
+  PerlDestDriver *self = (PerlDestDriver *)((gpointer *)user_data)[2];
+  gboolean need_drop = FALSE;
+  gboolean fallback = self->template_options.on_error & ON_ERROR_FALLBACK_TO_STRING;
+
+  switch (type)
+    {
+    case TYPE_HINT_INT32:
+      {
+        gint32 i;
+
+        if (type_cast_to_int32(value, &i, NULL))
+          hv_store(kvmap, name, strlen(name), newSViv(i), 0);
+        else
+          {
+            need_drop = type_cast_drop_helper(self->template_options.on_error,
+                                              value, "int");
+
+            if (fallback)
+              hv_store(kvmap, name, strlen(name), newSVpv(value, 0), 0);
+          }
+        break;
+      }
+    case TYPE_HINT_STRING:
+      hv_store(kvmap, name, strlen(name), newSVpv(value, 0), 0);
+      break;
+    default:
+      need_drop = type_cast_drop_helper(self->template_options.on_error,
+                                        value, "<unknown>");
+      break;
+    }
+  return need_drop;
+}
+
+/** Main code **/
+
+static gboolean
+perl_worker_eval(LogThrDestDriver *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+  gboolean success, need_drop;
+  LogMessage *msg;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  PerlInterpreter *my_perl = self->perl;
+  int count;
+  HV *kvmap;
+  gpointer args[3];
+  dSP;
+
+  success = log_queue_pop_head(self->super.queue, &msg, &path_options, FALSE, FALSE);
+  if (!success)
+    return TRUE;
+
+  msg_set_context(msg);
+
+  ENTER;
+  SAVETMPS;
+
+  PUSHMARK(SP);
+
+  kvmap = newHV();
+
+  args[0] = self->perl;
+  args[1] = kvmap;
+  args[2] = self;
+  need_drop = !value_pairs_foreach(self->vp, perl_worker_vp_add_one,
+                                   msg, self->seq_num, &self->template_options,
+                                   args);
+  if (need_drop && (self->template_options.on_error & ON_ERROR_DROP_MESSAGE))
+    goto exit;
+
+  XPUSHs(sv_2mortal(newRV_noinc((SV *)kvmap)));
+
+  PUTBACK;
+
+  count = call_pv(self->queue_func_name, G_EVAL | G_SCALAR);
+
+  SPAGAIN;
+
+  msg_set_context(NULL);
+
+  if (SvTRUE(ERRSV))
+    {
+      msg_error("Error while calling a Perl function",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("script", self->filename),
+                evt_tag_str("function", self->queue_func_name),
+                evt_tag_str("error-message", SvPV_nolen(ERRSV)),
+                NULL);
+      (void) POPs;
+      success = FALSE;
+    }
+
+  if (count != 1)
+    {
+      msg_error("Too many values returned by a Perl function",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("script", self->filename),
+                evt_tag_str("function", self->queue_func_name),
+                evt_tag_int("returned-values", count),
+                evt_tag_int("expected-values", 1),
+                NULL);
+      success = FALSE;
+    }
+  else
+    {
+      int r = POPi;
+
+      success = (r != 0);
+    }
+
+ exit:
+  PUTBACK;
+  FREETMPS;
+  LEAVE;
+
+  if (success && !need_drop)
+    {
+      stats_counter_inc(self->super.stored_messages);
+      step_sequence_number(&self->seq_num);
+      log_msg_ack(msg, &path_options);
+      log_msg_unref(msg);
+    }
+  else
+    {
+      stats_counter_inc(self->super.dropped_messages);
+      step_sequence_number(&self->seq_num);
+      log_msg_ack(msg, &path_options);
+      log_msg_unref(msg);
+    }
+
+  return success;
+}
+
+static gboolean
+perl_worker_init(LogPipe *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+  GlobalConfig *cfg = log_pipe_get_config(d);
+  char *argv[] = { "syslog-ng", self->filename };
+  PerlInterpreter *my_perl;
+
+  if (!self->filename)
+    {
+      msg_error("Error initializing Perl destination: no script specified!",
+                evt_tag_str("driver", self->super.super.super.id),
+                NULL);
+      return FALSE;
+    }
+
+  if (!log_dest_driver_init_method(d))
+    return FALSE;
+
+  log_template_options_init(&self->template_options, cfg);
+
+  self->perl = perl_alloc();
+  perl_construct(self->perl);
+  my_perl = self->perl;
+  PL_exit_flags |= PERL_EXIT_DESTRUCT_END;
+  perl_parse(self->perl, xs_init, 2, (char **)argv, NULL);
+
+  if (!self->queue_func_name)
+    self->queue_func_name = g_strdup("queue");
+
+  if (self->init_func_name)
+    _perl_call_func_noargs(self, self->init_func_name);
+
+  msg_verbose("Initializing Perl destination",
+              evt_tag_str("driver", self->super.super.super.id),
+              evt_tag_str("script", self->filename),
+              NULL);
+
+  return log_threaded_dest_driver_start(d);
+}
+
+static gboolean
+perl_worker_deinit(LogPipe *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  if (self->deinit_func_name)
+    _perl_call_func_noargs(self, self->deinit_func_name);
+
+  perl_destruct(self->perl);
+  perl_free(self->perl);
+
+  return log_threaded_dest_driver_deinit_method(d);
+}
+
+static void
+perl_dd_free(LogPipe *d)
+{
+  PerlDestDriver *self = (PerlDestDriver *)d;
+
+  log_template_options_destroy(&self->template_options);
+
+  g_free(self->filename);
+  g_free(self->init_func_name);
+  g_free(self->queue_func_name);
+  g_free(self->deinit_func_name);
+
+  if (self->vp)
+    value_pairs_free(self->vp);
+
+  log_threaded_dest_driver_free(d);
+}
+
+LogDriver *
+perl_dd_new(GlobalConfig *cfg)
+{
+  PerlDestDriver *self = g_new0(PerlDestDriver, 1);
+
+  log_threaded_dest_driver_init_instance(&self->super);
+
+  self->super.super.super.super.init = perl_worker_init;
+  self->super.super.super.super.deinit = perl_worker_deinit;
+  self->super.super.super.super.free_fn = perl_dd_free;
+
+  self->super.worker.disconnect = NULL;
+  self->super.worker.insert = perl_worker_eval;
+
+  self->super.format.stats_instance = perl_dd_format_stats_instance;
+  self->super.format.persist_name = perl_dd_format_persist_name;
+  self->super.stats_source = SCS_PERL;
+
+  init_sequence_number(&self->seq_num);
+
+  log_template_options_defaults(&self->template_options);
+  perl_dd_set_value_pairs(&self->super.super.super, value_pairs_new_default(cfg));
+
+  return (LogDriver *)self;
+}

--- a/modules/perl/perl-dest.h
+++ b/modules/perl/perl-dest.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PERL_DEST_H
+#define _SNG_PERL_DEST_H
+
+#include "driver.h"
+#include "logwriter.h"
+#include "value-pairs.h"
+
+LogDriver *perl_dd_new(GlobalConfig *cfg);
+void perl_dd_set_init_func(LogDriver *d, gchar *init_func_name);
+void perl_dd_set_queue_func(LogDriver *d, gchar *queue_func_name);
+void perl_dd_set_deinit_func(LogDriver *d, gchar *deinit_func_name);
+void perl_dd_set_filename(LogDriver *d, gchar *filename);
+void perl_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
+
+LogTemplateOptions *perl_dd_get_template_options(LogDriver *d);
+
+#endif

--- a/modules/perl/perl-example.conf
+++ b/modules/perl/perl-example.conf
@@ -1,0 +1,17 @@
+@version: 3.5
+
+log {
+  source { tcp(port(12345)); };
+  destination {
+    perl(
+	script("perl-example.pl")
+	init-func("init")
+	queue-func("queue")
+	deinit-func("deinit")
+        on-error("fallback-to-string")
+        value-pairs(scope(base)
+                    pair("foo.bar" "baz")
+                    pair("some-int" int("42")))
+    );
+  };
+};

--- a/modules/perl/perl-example.pl
+++ b/modules/perl/perl-example.pl
@@ -1,0 +1,24 @@
+use Data::Dumper;
+use strict;
+use warnings;
+
+BEGIN {
+	print "perl example loaded\n";
+}
+
+END {
+	print "perl example ending\n";
+}
+
+sub init {
+	print "This is the init function.\n";
+}
+
+sub queue {
+	my ($c) = @_;
+	print "QUEUE: " . Dumper($c) . "\n";
+}
+
+sub deinit {
+	print "This is the deinit function.\n";
+}

--- a/modules/perl/perl-grammar.ym
+++ b/modules/perl/perl-grammar.ym
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code requires {
+
+#include "perl-parser.h"
+#include "perl-dest.h"
+#include "value-pairs.h"
+#include "vptransform.h"
+
+}
+
+%code {
+
+#include "cfg-grammar.h"
+#include "cfg-parser.h"
+#include "plugin.h"
+}
+
+%name-prefix "perl_driver_"
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogDriver **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_PERL
+%token KW_SCRIPT
+%token KW_INIT_FUNC
+%token KW_QUEUE_FUNC
+%token KW_DEINIT_FUNC
+%token KW_GLOBALS
+
+%%
+
+start
+        : LL_CONTEXT_DESTINATION KW_PERL
+          {
+            last_driver = *instance = perl_dd_new(configuration);
+          }
+          '(' perl_options ')'         { YYACCEPT; }
+        ;
+
+perl_options
+        : perl_option perl_options
+        |
+        ;
+
+perl_option
+        : KW_SCRIPT '(' string ')'
+          {
+            perl_dd_set_filename(last_driver, $3);
+            free($3);
+          }
+        | KW_INIT_FUNC '(' string ')'
+          {
+            perl_dd_set_init_func(last_driver, $3);
+            free($3);
+          }
+        | KW_QUEUE_FUNC '(' string ')'
+          {
+            perl_dd_set_queue_func(last_driver, $3);
+            free($3);
+          }
+        | KW_DEINIT_FUNC '(' string ')'
+          {
+            perl_dd_set_deinit_func(last_driver, $3);
+            free($3);
+          }
+        | value_pair_option
+          {
+            perl_dd_set_value_pairs(last_driver, $1);
+          }
+        | dest_driver_option
+        | { last_template_options = perl_dd_get_template_options(last_driver); } template_option
+        ;
+
+perl_globals
+        : perl_global perl_globals
+        |
+        ;
+
+perl_global
+        : LL_IDENTIFIER '(' template_content ')'
+          {
+            value_pairs_add_pair(last_value_pairs, $1,  $3);
+            free($1);
+          }
+        | vp_option
+        ;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/perl/perl-parser.c
+++ b/modules/perl/perl-parser.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "perl-parser.h"
+#include "cfg-parser.h"
+#include "perl-grammar.h"
+
+extern int perl_debug;
+int perl_driver_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
+
+static CfgLexerKeyword perl_keywords[] = {
+  { "perl",                     KW_PERL },
+  { "script",                   KW_SCRIPT },
+  { "init_func",                KW_INIT_FUNC },
+  { "queue_func",               KW_QUEUE_FUNC },
+  { "deinit_func",              KW_DEINIT_FUNC },
+  { NULL }
+};
+
+CfgParser perl_parser =
+{
+#if ENABLE_DEBUG
+  .debug_flag = &perl_debug,
+#endif
+  .name = "perl",
+  .keywords = perl_keywords,
+  .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer)) perl_driver_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(perl_driver_, LogDriver **)

--- a/modules/perl/perl-parser.h
+++ b/modules/perl/perl-parser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_PERL_PARSER_H_INCLUDED
+#define SNG_PERL_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+#include "perl-dest.h"
+
+extern CfgParser perl_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(perl_driver_, LogDriver **)
+
+#endif

--- a/modules/perl/perl-plugin.c
+++ b/modules/perl/perl-plugin.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "perl-parser.h"
+#include "perl-dest.h"
+
+#include "plugin.h"
+#include "plugin-types.h"
+
+#include <EXTERN.h>
+#include <perl.h>
+
+extern CfgParser perl_parser;
+
+static Plugin perl_plugin =
+{
+  .type = LL_CONTEXT_DESTINATION,
+  .name = "perl",
+  .parser = &perl_parser,
+};
+
+gboolean
+perl_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
+{
+  int argc = 1;
+  char *argv[] = {"syslog-ng"};
+  char *env[] = {NULL};
+
+  PERL_SYS_INIT3(&argc, (char ***)&argv, (char ***)&env);
+
+  plugin_register(cfg, &perl_plugin, 1);
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "perl",
+  .version = VERSION,
+  .description = "The perl module provides Perl scripted destination support for syslog-ng.",
+  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .plugins = &perl_plugin,
+  .plugins_len = 1,
+};


### PR DESCRIPTION
This new module implements a fairly simple Perl destination, with which
one can write destination modules in Perl. The module will call three
functions: init, deinit and queue (the name of all three are
configurable, of course). The first two receive no arguments, the queue
method receives a hash map of key-value pairs, selected by
value-pairs().

It does some type hinting (int and string supported only, so far), and
does not support sub-hashes yet.

This fixes #21.

Requested-by: Fabien Wernli
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
