### PR TITLE
python: Add support for python3+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,9 @@ AC_ARG_ENABLE(luajit,
    [  --enable-luajit          Use luajit instead of standard liblua for Lua support],
    enable_luajit="yes",)
 
+AC_ARG_WITH(python,
+   [  --with-python=VERSION    Build with a specific version of python])
+
 dnl ***************************************************************************
 dnl Checks for programs.
 AC_PROG_YACC
@@ -139,7 +142,17 @@ fi
 dnl ***************************************************************************
 dnl python checks
 dnl ***************************************************************************
-PKG_CHECK_MODULES(PYTHON, python >= 2.6, enable_python="yes", enable_python="no")
+if test "x$with_python" != "xno"; then
+  case "$with_python" in
+    "yes"|"")
+        with_python="python"
+        ;;
+    [[0-9]]*)
+        with_python="python-${with_python}"
+        ;;
+  esac
+  PKG_CHECK_MODULES(PYTHON, $with_python >= 2.6, enable_python="yes", enable_python="no")
+fi
 
 dnl ***************************************************************************
 dnl misc features to be enabled
@@ -167,7 +180,7 @@ echo "  logmongource:        ${enable_logmongource:-yes}"
 echo "  lua:                 ${enable_lua:-yes} ${lua_mod:+($lua_mod)}"
 echo "  monitor-source:      ${enable_lua:-yes} ${lua_mod:+($lua_mod)}"
 echo "  perl:                ${enable_perl:-yes}"
-echo "  python:              ${enable_python:-yes}"
+echo "  python:              ${enable_python:-yes} (${with_python})"
 echo "  riemann:             ${enable_riemann:-yes}"
 echo "  rss                  yes"
 echo "  trigger-source       yes"

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -183,7 +183,7 @@ _py_function_return_value_as_bool(PythonDestDriver *self,
       return FALSE;
     }
 
-  if (PyInt_AsLong(ret) != 1)
+  if (PyLong_AsLong(ret) != 1)
     {
       msg_error("Python function returned FALSE",
                 evt_tag_str("driver", self->super.super.super.id),
@@ -234,19 +234,19 @@ python_worker_vp_add_one(const gchar *name,
         gint64 i;
 
         if (type_cast_to_int64(value, &i, NULL))
-          PyDict_SetItemString(dict, name, PyInt_FromLong(i));
+          PyDict_SetItemString(dict, name, PyLong_FromLong(i));
         else
           {
             need_drop = type_cast_drop_helper(self->template_options.on_error,
                                               value, "int");
 
             if (fallback)
-              PyDict_SetItemString(dict, name, PyString_FromString(value));
+              PyDict_SetItemString(dict, name, PyUnicode_FromString(value));
           }
         break;
       }
     case TYPE_HINT_STRING:
-      PyDict_SetItemString(dict, name, PyString_FromString(value));
+      PyDict_SetItemString(dict, name, PyUnicode_FromString(value));
       break;
     default:
       need_drop = type_cast_drop_helper(self->template_options.on_error,
@@ -363,7 +363,7 @@ _py_do_import(gpointer data, gpointer user_data)
   PythonDestDriver *self = (PythonDestDriver *)user_data;
   PyObject *module, *modobj;
 
-  module = PyString_FromString(modname);
+  module = PyUnicode_FromString(modname);
   if (!module)
     {
       msg_error("Error allocating Python string",
@@ -414,7 +414,7 @@ python_worker_init(LogPipe *d)
 
   g_list_foreach(self->imports, _py_do_import, self);
 
-  modname = PyString_FromString(self->filename);
+  modname = PyUnicode_FromString(self->filename);
   if (!modname)
     {
       msg_error("Unable to convert filename to Python string",


### PR DESCRIPTION
Added a --with-python=VERSION option to configure.ac, and changed the
python destination to work with both python2 and python3. Tested with
python 2.7 and 3.3.

The configure check defaults to searching for the unversioned "python"
package.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
