### PR TITLE
lua: Silence a compiler warning

### DIFF
--- a/modules/lua/lua-utils.c
+++ b/modules/lua/lua-utils.c
@@ -21,6 +21,8 @@
  *
  */
 
+#define LUA_COMPAT_MODULE
+
 #include "lua-utils.h"
 #include <lauxlib.h>
 #include "messages.h"


### PR DESCRIPTION
Define LUA_COMPAT_MODULE in lua-utils.c, to silence a compiler warning.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
