### PR TITLE
.travis.yml: Test with both Python2 and Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 /ylwrap
 
 /b/
+/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ install:
   - sudo ./add-release.sh syslog-ng-3.5
   - sudo apt-get update -qq
   - sudo apt-get install -qq aptitude
-  - sudo aptitude install -q -y pkg-config flex bison liblua5.2-dev libmongo-client-dev syslog-ng-dev libperl-dev python-dev libriemann-client-dev
+  - sudo aptitude install -q -y pkg-config flex bison liblua5.2-dev libmongo-client-dev syslog-ng-dev libperl-dev python-dev python3-dev libriemann-client-dev
 before_script:
   - autoreconf -i
 script:
-  - ./configure --enable-silent-rules
-  - make distcheck DESTDIR=$(pwd)/distcheck-dir
+  - travis/build --with-python=python2
+  - travis/build --with-python=python3
 compiler:
   - gcc
   - clang

--- a/travis/build
+++ b/travis/build
@@ -1,0 +1,11 @@
+#! /bin/sh
+set -e
+set -x
+
+builddir="build/$(date +%s)"
+install -d "${builddir}"
+cd "${builddir}"
+../../configure --enable-silent-rules $@
+make distcheck \
+     DESTDIR="$(pwd)/distcheck-dir" \
+     DISTCHECK_CONFIGURE_FLAGS="--enable-silent-rules $@"


### PR DESCRIPTION
This adjusts the Travis CI test suite to test with both python2 and
python3, and also enable silent rules for the distcheck, to make
warnings more visible.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
