### PR TITLE
configure: check for libperl.so, and do not try to build perl module if ...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,7 @@ dnl Perl checks
 dnl ***************************************************************************
 enable_perl="no"
 AC_CHECK_PROG(PERL, perl, perl)
+AC_CHECK_LIB(perl, perl_construct,,PERL="")
 if test "x$PERL" != "x"; then
   AC_MSG_CHECKING(for perl module ExtUtils::Embed)
   $PERL -e "use ExtUtils::Embed; exit" >/dev/null 2>&1


### PR DESCRIPTION
...not present.

Most ancient and modern Unices have perl interpreter installed, but not all of them have
libperl.so installed by default.
