### PR TITLE
configure.ac: Support compiling against a syslog-ng with internal ivykis

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,9 @@ dnl ***************************************************************************
 PKG_CHECK_MODULES(SYSLOG_NG, syslog-ng >= $SYSLOG_NG_MIN_VERSION)
 PKG_CHECK_MODULES(EVENTLOG, eventlog >= $EVENTLOG_MIN_VERSION)
 
-if test "x$with_ivykis" != "xno"; then
+syslog_ng_ivykis=[`pkg-config syslog-ng --variable ivykis`]
+
+if test "x$with_ivykis" != "xno" && test "x$syslog_ng_ivykis" != "xinternal"; then
    PKG_CHECK_MODULES(IVYKIS, ivykis >= $IVYKIS_MIN_VERSION,,true)
 fi
 


### PR DESCRIPTION
If syslog-ng was compiled with an internal ivykis, it will (in upcoming
versions) install the ivykis headers and adjust CFLAGS accordingly, so
that modules can be compiled against libsyslog-ng alone. This will be
marked with an "ivykis=internal" in the syslog-ng pkg-config control
file. When that is found, the Incubator need not look for a system-wide
Ivykis installation.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
