### PR TITLE
perl fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,6 @@ dnl ***************************************************************************
 enable_perl="no"
 AC_CHECK_PROG(PERL, perl, perl)
 
-AC_CHECK_LIB(perl, perl_construct, [true], [PERL=""])
 if test "x$PERL" != "x"; then
   AC_MSG_CHECKING(for perl module ExtUtils::Embed)
   $PERL -e "use ExtUtils::Embed; exit" >/dev/null 2>&1
@@ -139,6 +138,12 @@ if test "x$PERL" != "x"; then
     AC_MSG_RESULT(ok)
     enable_perl="yes"
   fi
+fi
+if test "x$enable_perl" != "xno"; then
+   LDFLAGS_SAVE="$LDFLAGS"
+   LDFLAGS="$LDFLAGS `$PERL -MExtUtils::Embed -e ldopts`"
+   AC_CHECK_LIB(perl, perl_construct, [true], enable_perl="no")
+   LDFLAGS="$LDFLAGS_SAVE"
 fi
 
 dnl ***************************************************************************


### PR DESCRIPTION
We're using ExtUtils::Embed to figure out the libraries needed for the
perl module, do not clobber the global LIBS when verifying that libperl
exists. Previously, everything got linked against libperl, which is
undesired.

Also, when detecting libperl, use ExtUtils::Embed to figure out the linker
options, so we can find it even if it is not on the default linker search
path.
