### PR TITLE
rss: Fix the module linking

### DIFF
--- a/modules/rss/Makefile.am
+++ b/modules/rss/Makefile.am
@@ -7,7 +7,7 @@ modules_rss_librss_la_CFLAGS		= \
 	-I$(top_srcdir)/modules/rss	  \
 	-I$(top_builddir)/modules/rss
 
-module_rss_librss_la_LIBS		= \
+modules_rss_librss_la_LIBADD		= \
 	$(SYSLOG_NG_LIBS)		  \
 	$(EVENTLOG_LIBS)
 


### PR DESCRIPTION
Correct the name of a variable, so that the RSS module will get
correctly linked to libsyslog-ng and others.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
