### PR TITLE
getent: Remove an unnecessary include statement

### DIFF
--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -33,7 +33,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
-#include <features.h>
 #include <stddef.h>
 
 typedef gboolean (*lookup_method)(gchar *key, gchar *member_name, GString *result);


### PR DESCRIPTION
We do not use <features.h> anywhere, no need to include it. This makes
the Incubator compile again on FreeBSD, thus fixes #50.

Reported-by: Peter Czanik czanik@balabit.hu
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
