### PR TITLE
lua: Reworked Lua destination to be a threaded destination.

### DIFF
--- a/modules/lua/lua-dest.h
+++ b/modules/lua/lua-dest.h
@@ -28,11 +28,12 @@
 #include "driver.h"
 #include "logwriter.h"
 #include "value-pairs.h"
+#include "logthrdestdrv.h"
 #include <lua.h>
 
 typedef struct _LuaDestDriver
 {
-  LogDestDriver super;
+  LogThrDestDriver super;
   lua_State *state;
   gchar *template_string;
   gchar *filename;


### PR DESCRIPTION
Lua was the simplest destination driver of all kind, but because it lacked any
kind of queue management or synchronization, it was easy to get it killed by
several parallel input connections. Not it was fixed by switching to threaded
destination driver.

@algernon: Could you please review it? This was a horrendous mistake, to do Lua that way, so i switched it to a threaded model. It was horribly easy to crash it, now it can work under several parallel connections. What was very interesting, is that when I use threaded(no), and only one connection as input, i still can get 300k msg/sec even with this threaded destination. But when i use threaded(yes) it goes back to 50k/sec.
