### PR TITLE
F/lua constant globals and variable params

### DIFF
--- a/modules/lua/lua-dest.h
+++ b/modules/lua/lua-dest.h
@@ -43,7 +43,8 @@ typedef struct _LuaDestDriver
   LogTemplate *template;
   LogTemplateOptions template_options;
   gint mode;
-  ValuePairs *globals;
+  ValuePairs *params;
+  GList *globals;
 } LuaDestDriver;
 
 LogDriver *lua_dd_new();
@@ -53,7 +54,10 @@ void lua_dd_set_deinit_func(LogDriver *d, gchar *deinit_func_name);
 void lua_dd_set_filename(LogDriver *d, gchar *filename);
 void lua_dd_set_template(LogDriver *d, LogTemplate *template);
 void lua_dd_set_mode(LogDriver *d, gchar *mode);
-void lua_dd_set_globals(LogDriver *d, ValuePairs *vp);
+void lua_dd_set_params(LogDriver *d, ValuePairs *vp);
+void lua_dd_add_global_constant(LogDriver *d, const char *name, const char *value);
+void lua_dd_add_global_constant_with_type_hint(LogDriver *d, const char *name, const char *value, const char *type_hint);
+void lua_dd_init_global_contants(LogDriver *d);
 
 LogTemplateOptions *lua_dd_get_template_options(LogDriver *d);
 

--- a/modules/lua/lua-grammar.ym
+++ b/modules/lua/lua-grammar.ym
@@ -53,6 +53,7 @@
 %token KW_DEINIT_FUNC
 %token KW_LUA_DEST_MODE
 %token KW_GLOBALS
+%token KW_PARAMS
 
 %%
 
@@ -99,24 +100,49 @@ lua_option
             lua_dd_set_mode(last_driver, $3);
             free($3);
           }
-        | KW_GLOBALS
+        | KW_PARAMS
           {
             last_value_pairs = value_pairs_new();
           }
-          '(' lua_globals ')'
+          '(' lua_params ')'
           {
-            lua_dd_set_globals(last_driver, last_value_pairs);
+            lua_dd_set_params(last_driver, last_value_pairs);
           }
+        | KW_GLOBALS {
+            lua_dd_init_global_contants(last_driver);
+          }
+          '(' lua_globals ')'
         | dest_driver_option
         | { last_template_options = lua_dd_get_template_options(last_driver); } template_option
         ;
 
-lua_globals
-        : lua_global lua_globals
+lua_globals 
+	: lua_global lua_globals
+	|
+	;
+
+lua_global
+	: LL_IDENTIFIER '(' string_or_number ')'
+	  {
+	     lua_dd_add_global_constant(last_driver, $1, $3);
+	     free($1);
+             free($3);
+          }
+	| LL_IDENTIFIER '(' LL_IDENTIFIER '(' string_or_number ')' ')'
+	  {
+	     lua_dd_add_global_constant_with_type_hint(last_driver, $1, $5, $3);
+	     free($1);
+             free($3);
+	     free($5);
+          }
+	;
+
+lua_params
+        : lua_param lua_params
         |
         ;
 
-lua_global
+lua_param
         : LL_IDENTIFIER '(' template_content ')'
           {
             value_pairs_add_pair(last_value_pairs, $1,  $3);

--- a/modules/lua/lua-parser.c
+++ b/modules/lua/lua-parser.c
@@ -37,6 +37,7 @@ static CfgLexerKeyword lua_keywords[] = {
   { "deinit_func",              KW_DEINIT_FUNC },
   { "mode",                     KW_LUA_DEST_MODE },
   { "globals",                  KW_GLOBALS },
+  { "params",                   KW_PARAMS },
   { NULL }
 };
 


### PR DESCRIPTION
Globals are now constants as they should ever be. There is a new feature
with the params() option, which works exactly as the old globals(), eg.
uses value pairs, and templates can be used. The result is manifested as a lua
table as the second parameter of the queue func. Although the same result
can be achieved by using raw mode and Template "class" in Lua, using params
is more comfortable in some cases (eg: SCL).

Examples:

conf:

destination d_lua {
  lua( queue-func("test_queue") globals( var1("test") ) params( param1("$HOST") ) );
};

lua:

function test_queue(msg, params)
  print(msg)
  print(params.param1)
end
