### PR TITLE
scl: Add a graphite() SCL

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -1,1 +1,2 @@
 include scl/elasticsearch/Makefile.am
+include scl/graphite/Makefile.am

--- a/scl/graphite/Makefile.am
+++ b/scl/graphite/Makefile.am
@@ -1,0 +1,6 @@
+goscldir	= ${scldir}/graphite
+
+goscl_DATA	= scl/graphite/plugin.conf
+
+EXTRA_DIST	+= scl/graphite/graphite-example.conf \
+		${goscl_DATA}

--- a/scl/graphite/graphite-example.conf
+++ b/scl/graphite/graphite-example.conf
@@ -1,0 +1,20 @@
+@version: 3.5
+@include "scl.conf"
+@include "scl/graphite/plugin.conf"
+
+source s_all {
+       internal();
+       system();
+};
+
+destination d_graphite {
+	graphite(
+		payload("--key monitor.*")
+        );
+};
+
+log {
+    source(s_all);
+    destination(d_graphite);
+    flags(flow-control);
+};

--- a/scl/graphite/plugin.conf
+++ b/scl/graphite/plugin.conf
@@ -1,0 +1,28 @@
+## scl/graphite/plugin.conf -- Graphite destination for syslog-ng
+##
+## Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+## Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+##
+## This program is free software; you can redistribute it and/or modify it
+## under the terms of the GNU General Public License version 2 as published
+## by the Free Software Foundation, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+##
+## As an additional exemption you are allowed to compile & link against the
+## OpenSSL libraries as published by the OpenSSL project. See the file
+## COPYING for details.
+
+block destination graphite(
+      host("localhost") port(2003)
+      payload("")) {
+  network("`host`" port(`port`) transport(tcp)
+          template("$(graphite-output `payload`)"));
+};


### PR DESCRIPTION
To make it easier to send metrics to Graphite, the graphite()
destination block will set up a pre-configured network destination, with
$(graphite-output) embedded. By default, the payload is empty, and one
must set the options passed to $(graphite-output) when using the SCL
block.

This closes #65.

Requested-by: Balazs Scheidler bazsi@balabit.hu
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
