### PR TITLE
syslog-ng 3.5.5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ also an example of a third party syslog-ng module.
 
  [sng]: https://github.com/balabit/syslog-ng
 
-**NOTE**: The Incubator requires syslog-ng 3.5.0rc1 or newer, but does
+**NOTE**: The Incubator requires syslog-ng 3.5.5 or newer, but does
   not work with 3.6!
 
 Contents

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ dnl ***************************************************************************
 dnl dependencies
 
 GLIB_MIN_VERSION="2.14"
-SYSLOG_NG_MIN_VERSION="3.5"
+SYSLOG_NG_MIN_VERSION="3.5.5"
 EVENTLOG_MIN_VERSION="0.2.10"
 IVYKIS_MIN_VERSION="0.30.0"
 LMC_MIN_VERSION="0.1.2"

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -130,7 +130,7 @@ tf_graphite_foreach_func(const gchar *name, TypeHint type, const gchar *value, g
 }
 
 static gboolean
-tf_graphite_format(GString *result, ValuePairs *vp, LogMessage *msg, const LogTemplateOptions *template_options, LogTemplate *timestamp_template)
+tf_graphite_format(GString *result, ValuePairs *vp, LogMessage *msg, const LogTemplateOptions *template_options, LogTemplate *timestamp_template, gint time_zone_mode)
 {
   TFGraphiteForeachUserData userdata;
   gboolean return_value;
@@ -139,7 +139,7 @@ tf_graphite_format(GString *result, ValuePairs *vp, LogMessage *msg, const LogTe
   userdata.formatted_unixtime = g_string_new("");
   log_template_format(timestamp_template, msg, NULL, 0, 0, NULL, userdata.formatted_unixtime);
 
-  return_value = value_pairs_foreach(vp, tf_graphite_foreach_func, msg, 0, template_options, &userdata);
+  return_value = value_pairs_foreach(vp, tf_graphite_foreach_func, msg, 0, time_zone_mode, template_options, &userdata);
 
   g_string_free(userdata.formatted_unixtime, FALSE);
   return return_value;
@@ -155,7 +155,7 @@ tf_graphite_call(LogTemplateFunction *self, gpointer s,
   gsize orig_size = result->len;
 
   for (i = 0; i < args->num_messages; i++)
-    r &= tf_graphite_format(result, state->vp, args->messages[i], args->opts, state->timestamp_template);
+    r &= tf_graphite_format(result, state->vp, args->messages[i], args->opts, state->timestamp_template, args->tz);
 
   if (!r && (args->opts->on_error & ON_ERROR_DROP_MESSAGE))
     g_string_set_size(result, orig_size);

--- a/modules/lua/lua-dest.c
+++ b/modules/lua/lua-dest.c
@@ -135,7 +135,7 @@ lua_dd_create_parameter_table_for_queue_func(lua_State *state, ValuePairs *param
 {
   lua_newtable(state);
   value_pairs_foreach(params, lua_dd_add_parameter_to_table, msg, 0,
-                      NULL, state);
+                      LTZ_SEND, NULL, state);
 }
 
 static gboolean

--- a/modules/perl/perl-dest.c
+++ b/modules/perl/perl-dest.c
@@ -301,8 +301,9 @@ perl_worker_eval(LogThrDestDriver *d)
   args[1] = kvmap;
   args[2] = self;
   vp_ok = value_pairs_foreach(self->vp, perl_worker_vp_add_one,
-                                   msg, self->seq_num, &self->template_options,
-                                   args);
+                              msg, self->seq_num, LTZ_SEND,
+                              &self->template_options,
+                              args);
   if (!vp_ok && (self->template_options.on_error & ON_ERROR_DROP_MESSAGE))
     goto exit;
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -272,7 +272,8 @@ _py_create_dict_from_message(PythonDestDriver *self, LogMessage *msg, PyObject *
   args[1] = dict;
 
   vp_ok = value_pairs_foreach(self->vp, python_worker_vp_add_one,
-                              msg, self->seq_num, &self->template_options,
+                              msg, self->seq_num,
+                              LTZ_SEND, &self->template_options,
                               args);
   PyTuple_SetItem(*func_args, 0, dict);
 

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -437,7 +437,7 @@ riemann_worker_insert(LogThrDestDriver *s)
 
       if (self->fields.attributes)
         value_pairs_foreach(self->fields.attributes, riemann_dd_field_add_attribute_vp,
-                            msg, self->seq_num, &self->template_options, event);
+                            msg, self->seq_num, LTZ_SEND, &self->template_options, event);
 
       riemann_client_send_message_oneshot
         (self->client,


### PR DESCRIPTION
syslog-ng 3.5.5 introduced an incompatible change in value-pairs, in
order to allow time-zone settings to propagate to value-pairs. This
patch ups the syslog-ng dependency, and updates all relevant modules.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
