### PR TITLE
scl: Fixed the elasticsearch SCL plugin

### DIFF
--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -23,9 +23,7 @@
 block destination elasticsearch(
       host("localhost") port(9200)
       index("syslog-ng") type("message")
-      body("$(format-json --scope rfc5424 --pair @timestamp=\"${R_ISODATE}\" \
-                          --pair @message=\"${MSG}\" \
-                          --exclude DATE --exclude MESSAGE)")) {
+      body("$(format-json --scope rfc5424 --pair @timestamp=\"${R_ISODATE}\" --pair @message=\"${MSG}\" --exclude DATE --exclude MESSAGE)")) {
   program("`scl-root`/elasticsearch/es-bridge `host` `port` `index` `type`"
           template("`body`\n")
   );


### PR DESCRIPTION
We can't break $(format-json) into multiple lines, as that produces a
syntax error. Changed the elasticsearch SCL plugin to have it on one
single line.

Reported-by: Peter Czanik czanik@balabit.hu
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
