### PR TITLE
modules: Do not count inserted/sent messages as stored ones.

### DIFF
--- a/modules/lua/lua-dest.c
+++ b/modules/lua/lua-dest.c
@@ -76,7 +76,6 @@ static void lua_dd_accept_message(LogMessage *msg, LogPathOptions *path_options)
 
 static void lua_dd_ack_message(LuaDestDriver *self, LogMessage *msg, LogPathOptions *path_options)
 {
-   stats_counter_inc(self->super.stored_messages);
    lua_dd_accept_message(msg, path_options);
 };
 

--- a/modules/perl/perl-dest.c
+++ b/modules/perl/perl-dest.c
@@ -354,7 +354,6 @@ perl_worker_eval(LogThrDestDriver *d)
 
   if (success && vp_ok)
     {
-      stats_counter_inc(self->super.stored_messages);
       step_sequence_number(&self->seq_num);
       log_msg_ack(msg, &path_options);
       log_msg_unref(msg);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -341,7 +341,6 @@ python_worker_eval(LogThrDestDriver *d)
 
   if (success && vp_ok)
     {
-      stats_counter_inc(self->super.stored_messages);
       step_sequence_number(&self->seq_num);
       log_msg_ack(msg, &path_options);
       log_msg_unref(msg);

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -450,7 +450,6 @@ riemann_worker_insert(LogThrDestDriver *s)
 
   if (success)
     {
-      stats_counter_inc(self->super.stored_messages);
       step_sequence_number(&self->seq_num);
       log_msg_ack(msg, &path_options);
       log_msg_unref(msg);


### PR DESCRIPTION
Stored messages are for only queued messages inside syslog-ng.
