### PR TITLE
java: Do not typedef the same thing twice

### DIFF
--- a/modules/java/java-destination-proxy.c
+++ b/modules/java/java-destination-proxy.c
@@ -42,7 +42,7 @@ typedef struct _JavaDestinationImpl
   jmethodID mi_flush;
 } JavaDestinationImpl;
 
-typedef struct _JavaDestinationProxy
+struct _JavaDestinationProxy
 {
   jclass loaded_class;
   JavaDestinationImpl dest_impl;
@@ -56,7 +56,7 @@ typedef struct _JavaDestinationProxy
   jmethodID loader_constructor;
   jmethodID mi_loadclass;
 
-} JavaDestinationProxy;
+};
 
 
 static gboolean


### PR DESCRIPTION
It is enough to typedef JavaDestinationProxy once, in the header, and
only have a struct in the .c file. Fixes #106.

Reported-by: Peter Czanik <czanik@balabit.hu>
Signed-off-by: Gergely Nagy <algernon@madhouse-project.org>