### PR TITLE
kafka: fix log callback signature

### DIFF
--- a/modules/kafka/kafka.c
+++ b/modules/kafka/kafka.c
@@ -85,7 +85,7 @@ typedef struct
 } KafkaDriver;
 
 void
-kafka_log(rd_kafka_t *rkt, int level,
+kafka_log(const rd_kafka_t *rkt, int level,
           const char *fac, const char *msg)
 {
   msg_event_suppress_recursions_and_send(


### PR DESCRIPTION
The first argument is expected to be constant. This has always been the
case for `rd_kafka_conf_set_log_cb()` function (see
https://github.com/edenhill/librdkafka/commit/a0d4400fe9032532a34f3d97ab6f0b70bf7d28c0)
and it seems that it has always been the case for
`rd_kafka_set_logger()` too (see
https://github.com/edenhill/librdkafka/commit/96b461570a74ad83c729172e27b72543d74d0ffd).