### PR TITLE
kafka: check for partition availability before selecting one

### DIFF
--- a/modules/kafka/kafka.c
+++ b/modules/kafka/kafka.c
@@ -113,8 +113,13 @@ int32_t kafka_partition(const rd_kafka_topic_t *rkt,
                         void *msgp)
 {
   u_int32_t key = *((u_int32_t *)keydata);
+  u_int32_t target = key % partition_cnt;
+  int32_t i = partition_cnt;
 
-  return key % partition_cnt;
+  while (--i > 0 && !rd_kafka_topic_partition_available(rkt, target)) {
+    target = (target + 1) % partition_cnt;
+  }
+  return target;
 }
 
 /*


### PR DESCRIPTION
When a partition is unavailable, sending to it will just lead to a lost
log. Therefore, after selecting the partition, check if it is
available. If not, select the next one until we tried them all.

A future iteration may use consistent hashing to avoid to double the
work done on a partition when the previous one is unavailable.