### PR TITLE
kafka: synchronously insert events into kafka

### DIFF
--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -51,6 +51,8 @@ extern GList *last_property;
 %token KW_PARTITION
 %token KW_RANDOM
 %token KW_FIELD
+%token KW_FLAGS
+%token KW_SYNC
 
 %%
 
@@ -88,6 +90,7 @@ kafka_option
             kafka_dd_set_props(last_driver, last_property);
             last_property = NULL;
         }
+        | KW_FLAGS '(' kafka_flags ')'
         | KW_PAYLOAD '(' template_content ')'
         {
             kafka_dd_set_payload(last_driver, $3);
@@ -111,6 +114,18 @@ kafka_property
             last_property = g_list_append(last_property, prop);
             free($1);
             free($3);
+        }
+        ;
+
+kafka_flags
+        : kafka_flag kafka_flags
+        |
+        ;
+
+kafka_flag
+        : KW_SYNC
+        {
+            kafka_dd_set_flag_sync(last_driver);
         }
         ;
 

--- a/modules/kafka/kafka-parser.c
+++ b/modules/kafka/kafka-parser.c
@@ -35,7 +35,8 @@ static CfgLexerKeyword kafka_keywords[] = {
     { "payload",        KW_PAYLOAD },
     { "properties",     KW_PROP },
     { "random",         KW_RANDOM },
-    { "topic",			KW_TOPIC },
+    { "topic",          KW_TOPIC },
+    { "sync",           KW_SYNC },
     { NULL }
 };
 

--- a/modules/kafka/kafka.c
+++ b/modules/kafka/kafka.c
@@ -122,6 +122,17 @@ int32_t kafka_partition(const rd_kafka_topic_t *rkt,
   return target;
 }
 
+static void
+kafka_worker_sync_produce_dr_cb(rd_kafka_t *rk,
+                                void *payload, size_t len,
+                                rd_kafka_resp_err_t err,
+                                void *opaque, void *msg_opaque)
+{
+  /* When done, just copy error code */
+  rd_kafka_resp_err_t *errp = (rd_kafka_resp_err_t *)msg_opaque;
+  *errp = err;
+}
+
 /*
  * Configuration
  */
@@ -151,6 +162,7 @@ kafka_dd_set_props(LogDriver *d, GList *props)
 #ifdef HAVE_LIBRDKAFKA_LOG_CB
   rd_kafka_conf_set_log_cb(conf, kafka_log);
 #endif
+  rd_kafka_conf_set_dr_cb(conf, kafka_worker_sync_produce_dr_cb);
 
   self->kafka = rd_kafka_new(RD_KAFKA_PRODUCER, conf,
                              errbuf, sizeof(errbuf));
@@ -191,7 +203,7 @@ kafka_dd_set_topic(LogDriver *d, const gchar *topic, GList *props)
 
   if (self->kafka == NULL)
     {
-      msg_error("kafka topic must set after kafka properties.", NULL);
+      msg_error("kafka topic must be set after kafka properties", NULL);
       return;
     }
 
@@ -313,34 +325,57 @@ kafka_worker_insert(LogThrDestDriver *s, LogMessage *msg)
       key = 0;
     }
 
-  rd_kafka_produce(self->topic,
-                   RD_KAFKA_PARTITION_UA,
-                   RD_KAFKA_MSG_F_COPY,
-                   self->payload_str->str,
-                   self->payload_str->len,
-                   &key, sizeof(key),
-                   NULL);
-  msg_debug("Kafka produce done", 
+#define KAFKA_INITIAL_ERROR_CODE -12345
+  rd_kafka_resp_err_t err = KAFKA_INITIAL_ERROR_CODE;
+  if (rd_kafka_produce(self->topic,
+                       RD_KAFKA_PARTITION_UA,
+                       RD_KAFKA_MSG_F_COPY,
+                       self->payload_str->str,
+                       self->payload_str->len,
+                       &key, sizeof(key),
+                       &err) == -1)
+    {
+      msg_error("Failed to add message to Kafka topic!",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("error", rd_kafka_err2str(rd_kafka_errno2err(errno))),
+                NULL);
+      return WORKER_INSERT_RESULT_ERROR;
+    }
+
+  msg_debug("Kafka produce done",
             evt_tag_str("driver", self->super.super.super.id),
             NULL);
 
-  rd_kafka_poll(self->kafka, 0);
+  /* Wait for completion. */
+  while (err == KAFKA_INITIAL_ERROR_CODE)
+    {
+      rd_kafka_poll(self->kafka, 5000);
+      if (err == -12345)
+        {
+          msg_debug("Kafka producer is freezed",
+                    evt_tag_str("driver", self->super.super.super.id),
+                    evt_tag_str("topic", self->topic_name),
+                    NULL);
+        }
+    }
+  if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
+    {
+      msg_error("Failed to add message to Kafka topic!",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("error", rd_kafka_err2str(err)),
+                NULL);
+      return WORKER_INSERT_RESULT_ERROR;
+    }
 
   msg_debug("Kafka event sent",
             evt_tag_str("driver", self->super.super.super.id),
             evt_tag_str("topic", self->topic_name),
             evt_tag_str("payload", self->payload_str->str),
             NULL);
-  success = TRUE;
 
-  if (success)
-    {
-      return WORKER_INSERT_RESULT_SUCCESS;
-    }
-  else
-    {
-      return WORKER_INSERT_RESULT_DROP;
-    }
+  return WORKER_INSERT_RESULT_SUCCESS;
 }
 
 static void

--- a/modules/kafka/kafka.h
+++ b/modules/kafka/kafka.h
@@ -32,6 +32,7 @@ void kafka_dd_set_partition_random(LogDriver *d);
 void kafka_dd_set_props(LogDriver *d, GList *props);
 void kafka_dd_set_topic(LogDriver *d, const gchar *topic, GList *props);
 void kafka_dd_set_payload(LogDriver *d, LogTemplate *payload);
+void kafka_dd_set_flag_sync(LogDriver *d);
 LogTemplateOptions *kafka_dd_get_template_options(LogDriver *d);
 void kafka_property_free(void *p);
 


### PR DESCRIPTION
This allows us to check for errors and avoid losing logs. However, this
makes the insertion quite slow.

The PR is WIP, I will investigate more about the performance issue. Moreover, if Kafka is unavailable, the thread will just wait forever. Maybe we should fail after some time instead?

cc @pyr