### PR TITLE
date-parser: introduce a new parser for date

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Contents
   
    [sng:java]: https://github.com/balabit/syslog-ng-incubator/tree/master/modules/java/
 
+ * [Date parser][sng:date]: A parser for arbitrary date formats which
+   may be contained in non-syslog messages.
+  
+   [sng:date]: https://github.com/balabit/syslog-ng-incubator/tree/master/modules/date/
+
 Installation
 ------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,8 @@ AC_ARG_ENABLE(zmq,
 
 AC_ARG_ENABLE(java, [ --enable-java  Enable java destination (default: auto)],, enable_java="auto")
 
+AC_ARG_ENABLE(date, [ --enable-date  Enable date parser (default: yes)],, enable_date="yes")
+
 dnl ***************************************************************************
 dnl Checks for programs.
 AC_PROG_YACC
@@ -317,6 +319,7 @@ AM_CONDITIONAL(ENABLE_KAFKA, [test "x$enable_kafka" = "xyes"])
 AM_CONDITIONAL(ENABLE_ZMQ, [test "$enable_zmq" != "no"])
 AM_CONDITIONAL(ENABLE_GROK, [test "$enable_grok" != "no"])
 AM_CONDITIONAL(ENABLE_JAVA, [test "$enable_java" = "yes"])
+AM_CONDITIONAL(ENABLE_DATE, [test "$enable_date" = "yes"])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
@@ -338,5 +341,6 @@ echo "  trigger-source       yes"
 echo "  tfgetent             yes"
 echo "  zmq                  ${enable_zmq:=no}"
 echo "  grok-parser          ${enable_grok}"
+echo "  date-parser          ${enable_date}"
 echo "  java                 ${enable_java:=no}"
 echo

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -10,3 +10,4 @@ include modules/kafka/Makefile.am
 include modules/zmq/Makefile.am
 include modules/grok/Makefile.am
 include modules/java/Makefile.am
+include modules/date/Makefile.am

--- a/modules/date/Makefile.am
+++ b/modules/date/Makefile.am
@@ -1,0 +1,39 @@
+if ENABLE_DATE
+module_LTLIBRARIES += modules/date/libdate-parser.la
+
+modules_date_libdate_parser_la_CFLAGS	 = \
+	$(INCUBATOR_CFLAGS)			   \
+	-I$(top_srcdir)/modules/date		   \
+	-I$(top_builddir)/modules/date
+
+modules_date_libdate_parser_la_SOURCES	 = \
+	modules/date/date-parser-grammar.y	   \
+	modules/date/date-parser.c		   \
+	modules/date/date-parser.h		   \
+	modules/date/date-parser-parser.c	   \
+	modules/date/date-parser-parser.h	   \
+	modules/date/date-parser-plugin.c
+
+modules_date_libdate_parser_la_LIBADD	 = \
+	$(INCUBATOR_LIBS)
+
+modules_date_libdate_parser_la_LDFLAGS	 = \
+	-avoid-version -module -no-undefined
+
+BUILT_SOURCES						+= \
+	modules/date/date-parser-grammar.y	   \
+	modules/date/date-parser-grammar.c	   \
+	modules/date/date-parser-grammar.h
+
+include modules/date/tests/Makefile.am
+
+modules/date-parser mod-date: modules/date/libdate-parser.la
+else
+modules/date-parser mod-date:
+endif
+
+
+EXTRA_DIST += \
+	modules/date/date-parser-grammar.ym
+
+.PHONY: modules/date mod-date

--- a/modules/date/README.md
+++ b/modules/date/README.md
@@ -1,0 +1,46 @@
+date parser
+===========
+
+The date parser can extract dates from non-syslog messages. It
+operates by default on `$MSG` but any template can be provided. The
+date will be stored as the sender date and the remaining of the
+message (if any) is discarded. Therefore, the result can be accessed
+using any of the `S_` macros (`${S_DATE}`, `${S_ISODATE}`,
+`${S_MONTH}`, …).
+
+Example config:
+
+```
+source s_apache {
+  channel {
+    source {
+      file("/var/log/apache/access.log" flags(no-parse));
+     };
+     parser(p_apache_parser);
+    };
+  };
+};
+
+parser p_apache_parser {
+  csv-parser(columns("APACHE.CLIENT_IP", "APACHE.IDENT_NAME", "APACHE.USER_NAME",
+                     "APACHE.TIMESTAMP", "APACHE.REQUEST_URL", "APACHE.REQUEST_STATUS",
+                     "APACHE.CONTENT_LENGTH", "APACHE.REFERER", "APACHE.USER_AGENT",
+                     "APACHE.PROCESS_TIME", "APACHE.SERVER_NAME")
+             flags(escape-double-char,strip-whitespace)
+             delimiters(" ")
+             quote-pairs('""[]'));
+
+  date-parser(
+       format("%d/%b/%Y:%H:%M:%S %Z")
+       template("${APACHE.TIMESTAMP}"));
+};
+
+destination d_file {
+  file("/var/log/messages");
+};
+
+log {
+  source(s_apache);
+  destination(d_file);
+};
+```

--- a/modules/date/date-parser-grammar.ym
+++ b/modules/date/date-parser-grammar.ym
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code requires {
+
+#include "date-parser-parser.h"
+
+}
+
+%code {
+
+#include "cfg-grammar.h"
+#include "cfg-parser.h"
+#include "plugin.h"
+#include "parser/parser-expr.h"
+#include "date-parser.h"
+
+LogParser *last_parser;
+}
+
+%name-prefix "date_"
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogParser **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_DATE
+%token KW_DATE_OFFSET
+%token KW_DATE_FORMAT
+
+%%
+
+start
+        : LL_CONTEXT_PARSER date_parser { YYACCEPT; }
+        ;
+
+date_parser
+        : KW_DATE '('
+          {
+            last_parser = *instance = date_parser_new (configuration);
+          }
+          date_parser_options ')'
+        ;
+
+date_parser_options
+        : date_parser_option date_parser_options
+        |
+        ;
+
+date_parser_option
+	: KW_DATE_OFFSET '(' LL_NUMBER ')' { date_parser_set_offset(last_parser, $3); }
+        | KW_DATE_FORMAT '(' string ')' { date_parser_set_format(last_parser, $3); free($3); }
+        | parser_opt
+        ;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/date/date-parser-grammar.ym
+++ b/modules/date/date-parser-grammar.ym
@@ -49,6 +49,7 @@ LogParser *last_parser;
 %token KW_DATE
 %token KW_DATE_OFFSET
 %token KW_DATE_FORMAT
+%token KW_TIME_ZONE
 
 %%
 
@@ -72,6 +73,7 @@ date_parser_options
 date_parser_option
 	: KW_DATE_OFFSET '(' LL_NUMBER ')' { date_parser_set_offset(last_parser, $3); }
         | KW_DATE_FORMAT '(' string ')' { date_parser_set_format(last_parser, $3); free($3); }
+        | KW_TIME_ZONE '(' string ')' { date_parser_set_timezone(last_parser, $3); free($3); }
         | parser_opt
         ;
 

--- a/modules/date/date-parser-parser.c
+++ b/modules/date/date-parser-parser.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "date-parser.h"
+#include "cfg-parser.h"
+#include "date-parser-grammar.h"
+#include "date-parser-parser.h"
+
+extern int date_parser_debug;
+int date_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
+
+static CfgLexerKeyword date_keywords[] = {
+  { "date_parser", KW_DATE },
+  { "offset",      KW_DATE_OFFSET },
+  { "format",      KW_DATE_FORMAT },
+  { NULL }
+};
+
+CfgParser date_parser =
+{
+#if ENABLE_DEBUG
+  .debug_flag = &date_parser_debug,
+#endif
+  .name = "date-parser",
+  .keywords = date_keywords,
+  .parse = (int (*)(CfgLexer *, gpointer *, gpointer)) date_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(date_, LogParser **);

--- a/modules/date/date-parser-parser.h
+++ b/modules/date/date-parser-parser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_TRIGGER_SOURCE_PARSER_H_INCLUDED
+#define SNG_TRIGGER_SOURCE_PARSER_H_INCLUDED
+
+#include "date-parser.h"
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+
+extern CfgParser date_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(date_, LogParser **)
+
+#endif

--- a/modules/date/date-parser-plugin.c
+++ b/modules/date/date-parser-plugin.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "date-parser.h"
+#include "date-parser-parser.h"
+
+#include "plugin.h"
+#include "plugin-types.h"
+
+extern CfgParser date_parser;
+
+static Plugin date_plugin =
+{
+  .type = LL_CONTEXT_PARSER,
+  .name = "date-parser",
+  .parser = &date_parser,
+};
+
+gboolean
+date_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
+{
+  plugin_register(cfg, &date_plugin, 1);
+  return TRUE;
+}
+
+const ModuleInfo module_info =
+{
+  .canonical_name = "date",
+  .version = VERSION,
+  .description = "Experimental date parser.",
+  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .plugins = &date_plugin,
+  .plugins_len = 1,
+};

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "date-parser.h"
+#include "scratch-buffers.h"
+
+#define KEY_BUFFER_LENGTH 1024
+
+typedef struct _DateParser
+{
+  LogParser super;
+  goffset date_offset;
+  gchar *date_format;
+} DateParser;
+
+void
+date_parser_set_offset (LogParser *s, goffset offset)
+{
+  DateParser *self = (DateParser *)s;
+  self->date_offset = offset;
+}
+
+void date_parser_set_format (LogParser *s, gchar *format)
+{
+  DateParser *self = (DateParser *)s;
+  if (self->date_format)
+    g_free (self->date_format);
+
+  self->date_format = g_strdup (format);
+}
+
+static gboolean
+date_parser_init (LogPipe *parser)
+{
+  DateParser *self = (DateParser *)parser;
+  GlobalConfig *cfg = log_pipe_get_config (&self->super.super);
+
+  return TRUE;
+};
+
+static gboolean
+date_parser_process (LogParser *s,
+                     LogMessage **pmsg,
+                     const LogPathOptions *path_options,
+                     const gchar *input,
+                     gsize input_len)
+{
+  const gchar *src = input;
+  char *cloned_input;
+  char *remaining;
+  DateParser *self = (DateParser *)s;
+  LogMessage *msg = log_msg_make_writable (pmsg, path_options);
+  struct tm tm;
+  memset(&tm, 0, sizeof(struct tm));
+
+  if (self->date_offset > input_len) return FALSE;
+  input += self->date_offset;
+  input_len -= self->date_offset;
+
+  /* Parse date */
+  cloned_input = g_strndup(input, input_len);
+  if (!cloned_input) return FALSE;
+  remaining = strptime(cloned_input, self->date_format, &tm);
+  g_free(cloned_input);
+
+  if (remaining == NULL) return FALSE;
+
+  /* mktime handles timezones horribly. It considers the time to be
+     local and also alter the parsed timezone. Try to fix all that. */
+  msg->timestamps[LM_TS_STAMP].zone_offset = tm.tm_gmtoff;
+  msg->timestamps[LM_TS_STAMP].tv_sec = mktime(&tm) - msg->timestamps[LM_TS_STAMP].zone_offset - timezone;
+  msg->timestamps[LM_TS_STAMP].tv_usec = 0;
+
+  return TRUE;
+};
+
+static LogPipe *
+date_parser_clone (LogPipe *s)
+{
+  DateParser *self = (DateParser *) s;
+
+  DateParser *cloned = (DateParser *) date_parser_new (log_pipe_get_config (&self->super.super));
+  g_free(cloned->date_format);
+  cloned->date_offset = self->date_offset;
+  cloned->date_format = g_strdup (self->date_format);
+  cloned->super.template = log_template_ref (self->super.template);
+
+  return &cloned->super.super;
+};
+
+static void
+date_parser_free (LogPipe *s)
+{
+  DateParser *self = (DateParser *)s;
+
+  g_free (self->date_format);
+
+  log_parser_free_method (s);
+};
+
+LogParser *date_parser_new (GlobalConfig *cfg)
+{
+  DateParser *self = g_new0 (DateParser, 1);
+  log_parser_init_instance (&self->super, cfg);
+  self->super.super.init = date_parser_init;
+  self->super.process = date_parser_process;
+  self->super.super.clone = date_parser_clone;
+  self->super.super.free_fn = date_parser_free;
+
+  self->date_format = g_strdup ("%FT%T%z");
+
+  return &self->super;
+};

--- a/modules/date/date-parser.c
+++ b/modules/date/date-parser.c
@@ -31,6 +31,8 @@ typedef struct _DateParser
   LogParser super;
   goffset date_offset;
   gchar *date_format;
+  gchar *date_tz;
+  TimeZoneInfo *date_tz_info;
 } DateParser;
 
 void
@@ -47,6 +49,18 @@ void date_parser_set_format (LogParser *s, gchar *format)
     g_free (self->date_format);
 
   self->date_format = g_strdup (format);
+}
+
+void date_parser_set_timezone (LogParser *s, gchar *tz)
+{
+  DateParser *self = (DateParser *)s;
+  if (self->date_tz)
+    g_free (self->date_tz);
+
+  self->date_tz = g_strdup (tz);
+  if (self->date_tz_info)
+    time_zone_info_free (self->date_tz_info);
+  self->date_tz_info = time_zone_info_new (self->date_tz);
 }
 
 static gboolean
@@ -87,9 +101,25 @@ date_parser_process (LogParser *s,
 
   /* mktime handles timezones horribly. It considers the time to be
      local and also alter the parsed timezone. Try to fix all that. */
-  msg->timestamps[LM_TS_STAMP].zone_offset = tm.tm_gmtoff;
-  msg->timestamps[LM_TS_STAMP].tv_sec = mktime(&tm) - msg->timestamps[LM_TS_STAMP].zone_offset - timezone;
   msg->timestamps[LM_TS_STAMP].tv_usec = 0;
+  if (!self->date_tz_info)
+    {
+      msg->timestamps[LM_TS_STAMP].zone_offset = tm.tm_gmtoff;
+      msg->timestamps[LM_TS_STAMP].tv_sec = mktime (&tm) - msg->timestamps[LM_TS_STAMP].zone_offset - timezone;
+    }
+  else
+    {
+      msg->timestamps[LM_TS_STAMP].tv_sec = mktime (&tm) - timezone;
+      msg->timestamps[LM_TS_STAMP].zone_offset =
+        time_zone_info_get_offset(self->date_tz_info,
+                                  msg->timestamps[LM_TS_STAMP].tv_sec);
+      if (msg->timestamps[LM_TS_STAMP].zone_offset == -1)
+        {
+          msg->timestamps[LM_TS_STAMP].zone_offset =
+            get_local_timezone_ofs(msg->timestamps[LM_TS_STAMP].tv_sec);
+        }
+      msg->timestamps[LM_TS_STAMP].tv_sec -= msg->timestamps[LM_TS_STAMP].zone_offset;
+    }
 
   return TRUE;
 };
@@ -100,9 +130,14 @@ date_parser_clone (LogPipe *s)
   DateParser *self = (DateParser *) s;
 
   DateParser *cloned = (DateParser *) date_parser_new (log_pipe_get_config (&self->super.super));
-  g_free(cloned->date_format);
+  g_free (cloned->date_format);
+  g_free (self->date_tz);
+  if (self->date_tz_info)
+    time_zone_info_free (self->date_tz_info);
   cloned->date_offset = self->date_offset;
   cloned->date_format = g_strdup (self->date_format);
+  cloned->date_tz = g_strdup (self->date_tz);
+  cloned->date_tz_info = time_zone_info_new (cloned->date_tz);
   cloned->super.template = log_template_ref (self->super.template);
 
   return &cloned->super.super;
@@ -114,6 +149,9 @@ date_parser_free (LogPipe *s)
   DateParser *self = (DateParser *)s;
 
   g_free (self->date_format);
+  g_free (self->date_tz);
+  if (self->date_tz_info)
+    time_zone_info_free (self->date_tz_info);
 
   log_parser_free_method (s);
 };

--- a/modules/date/date-parser.h
+++ b/modules/date/date-parser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2015 Vincent Bernat <Vincent.Bernat@exoscale.ch>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_TRIGGER_SOURCE_H_INCLUDED
+#define SNG_TRIGGER_SOURCE_H_INCLUDED
+
+#include "parser/parser-expr.h"
+
+LogParser *date_parser_new(GlobalConfig *cfg);
+
+void date_parser_set_offset (LogParser *s, goffset offset);
+void date_parser_set_format (LogParser *s, gchar *format);
+#endif

--- a/modules/date/date-parser.h
+++ b/modules/date/date-parser.h
@@ -30,4 +30,5 @@ LogParser *date_parser_new(GlobalConfig *cfg);
 
 void date_parser_set_offset (LogParser *s, goffset offset);
 void date_parser_set_format (LogParser *s, gchar *format);
+void date_parser_set_timezone (LogParser *s, gchar *tz);
 #endif

--- a/modules/date/tests/Makefile.am
+++ b/modules/date/tests/Makefile.am
@@ -1,0 +1,13 @@
+modules_date_tests_TESTS = \
+	modules/date/tests/test_date
+
+check_PROGRAMS += \
+	${modules_date_tests_TESTS}
+
+modules_date_tests_test_date_CFLAGS = \
+	$(INCUBATOR_CFLAGS)
+
+modules_date_tests_test_date_LDADD = \
+	$(INCUBATOR_TEST_LDADD) $(INCUBATOR_LIBS) \
+	$(top_builddir)/modules/date/libdate-parser.la
+

--- a/modules/date/tests/test_date.c
+++ b/modules/date/tests/test_date.c
@@ -7,7 +7,7 @@
 MsgFormatOptions parse_options;
 
 static void
-testcase(gchar *msg, goffset offset, gchar *format, gchar *expected)
+testcase(gchar *msg, goffset offset, gchar *timezone, gchar *format, gchar *expected)
 {
   LogTemplate *templ;
   LogMessage *logmsg;
@@ -20,6 +20,7 @@ testcase(gchar *msg, goffset offset, gchar *format, gchar *expected)
 
   date_parser_set_offset(parser, offset);
   if (format != NULL) date_parser_set_format(parser, format);
+  if (timezone != NULL) date_parser_set_timezone(parser, timezone);
 
   parse_options.flags = 0;
   logmsg = log_msg_new_empty();
@@ -62,22 +63,27 @@ int main()
   msg_format_options_init(&parse_options, configuration);
 
   /* Various ISO8601 formats */
-  testcase("2015-01-26T16:14:49+03:00", 0, NULL, "2015-01-26T16:14:49+03:00");
-  // testcase("2015-01-26T16:14:49+03:30", 0, NULL, "2015-01-26T16:14:49+03:30");
-  testcase("2015-01-26T16:14:49+0200", 0, NULL, "2015-01-26T16:14:49+02:00");
-  // testcase("2015-01-26T16:14:49Z", 0, NULL, "2015-01-26T16:14:49+00:00");
+  testcase("2015-01-26T16:14:49+03:00", 0, NULL, NULL, "2015-01-26T16:14:49+03:00");
+  // testcase("2015-01-26T16:14:49+03:30", 0, NULL, NULL, "2015-01-26T16:14:49+03:30");
+  testcase("2015-01-26T16:14:49+0200", 0, NULL, NULL, "2015-01-26T16:14:49+02:00");
+  // testcase("2015-01-26T16:14:49Z", 0, NULL, NULL, "2015-01-26T16:14:49+00:00");
 
   /* RFC 2822 */
-  testcase("Tue, 27 Jan 2015 11:48:46 +0200", 0, "%a, %d %b %Y %T %z", "2015-01-27T11:48:46+02:00");
+  testcase("Tue, 27 Jan 2015 11:48:46 +0200", 0, NULL, "%a, %d %b %Y %T %z", "2015-01-27T11:48:46+02:00");
 
   /* Apache-like */
-  testcase("21/Jan/2015:14:40:07 +0500", 0, "%d/%b/%Y:%T %z", "2015-01-21T14:40:07+05:00");
+  testcase("21/Jan/2015:14:40:07 +0500", 0, NULL, "%d/%b/%Y:%T %z", "2015-01-21T14:40:07+05:00");
 
   /* Try with additional text at the end */
-  testcase("2015-01-26T16:14:49+03:00 Disappointing log file", 0, NULL, "2015-01-26T16:14:49+03:00");
+  testcase("2015-01-26T16:14:49+03:00 Disappointing log file", 0, NULL, NULL, "2015-01-26T16:14:49+03:00");
 
   /* Try with offset */
-  testcase("<34> 2015-01-26T16:14:49+03:00 Disappointing log file", 5, NULL, "2015-01-26T16:14:49+03:00");
+  testcase("<34> 2015-01-26T16:14:49+03:00 Disappointing log file", 5, NULL, NULL, "2015-01-26T16:14:49+03:00");
+
+  /* Dates without timezones. America/Phoenix has no DST */
+  testcase("Tue, 27 Jan 2015 11:48:46", 0, NULL, "%a, %d %b %Y %T", "2015-01-27T11:48:46+00:00");
+  testcase("Tue, 27 Jan 2015 11:48:46", 0, "America/Phoenix", "%a, %d %b %Y %T", "2015-01-27T11:48:46-07:00");
+  testcase("Tue, 27 Jan 2015 11:48:46", 0, "+05:00", "%a, %d %b %Y %T", "2015-01-27T11:48:46+05:00");
 
   app_shutdown();
   return 0;

--- a/modules/date/tests/test_date.c
+++ b/modules/date/tests/test_date.c
@@ -1,0 +1,84 @@
+#include "modules/date/date-parser.h"
+#include <apphook.h>
+#include <libtest/testutils.h>
+#include <libtest/template_lib.h>
+#include <locale.h>
+
+MsgFormatOptions parse_options;
+
+static void
+testcase(gchar *msg, goffset offset, gchar *format, gchar *expected)
+{
+  LogTemplate *templ;
+  LogMessage *logmsg;
+  NVTable *nvtable;
+  GlobalConfig *cfg = cfg_new (0x302);
+  LogParser *parser = date_parser_new (cfg);
+  gboolean success;
+  const gchar *context_id = "test-context-id";
+  GString *res = g_string_sized_new(128);
+
+  date_parser_set_offset(parser, offset);
+  if (format != NULL) date_parser_set_format(parser, format);
+
+  parse_options.flags = 0;
+  logmsg = log_msg_new_empty();
+  log_msg_set_value(logmsg, log_msg_get_value_handle("MESSAGE"), msg, -1);
+  nvtable = nv_table_ref(logmsg->payload);
+  success = log_parser_process(parser, &logmsg, NULL, log_msg_get_value(logmsg, LM_V_MESSAGE, NULL), -1);
+  nv_table_unref(nvtable);
+
+  if (!success)
+    {
+      fprintf(stderr, "unable to parse offset=%d format=%s msg=%s\n", offset, format, msg);
+      exit(1);
+    }
+
+  /* Convert to ISODATE */
+  templ = compile_template("${ISODATE}", FALSE);
+  log_template_format(templ, logmsg, NULL, LTZ_LOCAL, 999, context_id, res);
+  assert_nstring(res->str, res->len, expected, strlen(expected),
+                 "incorrect date parsed msg=%s offset=%d format=%s",
+                 msg, offset, format);
+  log_template_unref(templ);
+  g_string_free(res, TRUE);
+
+  log_pipe_unref(&parser->super);
+  log_msg_unref(logmsg);
+  return;
+}
+
+
+int main()
+{
+  app_startup();
+
+  setlocale (LC_ALL, "C");
+  putenv("TZ=CET-1");
+  tzset();
+
+  configuration = cfg_new(0x0302);
+  msg_format_options_defaults(&parse_options);
+  msg_format_options_init(&parse_options, configuration);
+
+  /* Various ISO8601 formats */
+  testcase("2015-01-26T16:14:49+03:00", 0, NULL, "2015-01-26T16:14:49+03:00");
+  // testcase("2015-01-26T16:14:49+03:30", 0, NULL, "2015-01-26T16:14:49+03:30");
+  testcase("2015-01-26T16:14:49+0200", 0, NULL, "2015-01-26T16:14:49+02:00");
+  // testcase("2015-01-26T16:14:49Z", 0, NULL, "2015-01-26T16:14:49+00:00");
+
+  /* RFC 2822 */
+  testcase("Tue, 27 Jan 2015 11:48:46 +0200", 0, "%a, %d %b %Y %T %z", "2015-01-27T11:48:46+02:00");
+
+  /* Apache-like */
+  testcase("21/Jan/2015:14:40:07 +0500", 0, "%d/%b/%Y:%T %z", "2015-01-21T14:40:07+05:00");
+
+  /* Try with additional text at the end */
+  testcase("2015-01-26T16:14:49+03:00 Disappointing log file", 0, NULL, "2015-01-26T16:14:49+03:00");
+
+  /* Try with offset */
+  testcase("<34> 2015-01-26T16:14:49+03:00 Disappointing log file", 5, NULL, "2015-01-26T16:14:49+03:00");
+
+  app_shutdown();
+  return 0;
+};


### PR DESCRIPTION
It is currently based on `strptime()`. This brings four major drawbacks:

 - it is not ultra-fast
 - it is unable to handle some format (for example, the `Z` in `2006-08-07T12:34:56Z`)
 - it is locale-dependent (and cannot parse `Tue` if locale is `fr_FR`)
 - its handling of time zones is not portable and implementation-dependent

This is a WIP. I will likely replace the use of `strptime()` to something more portable. Also, the quality may be a bit off since I have no experience in writting a parser for syslog-ng. This is a mix of the Grok parser and the CSV parser.