### PR TITLE
kafka: don't version kafka library and ensure it can be dlopened

### DIFF
--- a/modules/kafka/Makefile.am
+++ b/modules/kafka/Makefile.am
@@ -17,6 +17,9 @@ modules_kafka_libkafka_la_SOURCES	=	\
 modules_kafka_libkafka_la_LIBADD	=	\
 	$(RDKAFKA_LIBS) $(INCUBATOR_LIBS)
 
+modules_kafka_libkafka_la_LDFLAGS	=	\
+	-avoid-version -module -no-undefined
+
 modules/kafka modules/kafka/ mod-kafka: \
 	modules/kafka/libkafka.la
 else


### PR DESCRIPTION
Without `-avoid-version`, on installation, we get `libkafka.so`,
`libkafka.so.0` and `libkafka.so.0.0.0`. This is useless.