### PR TITLE
Zmq warning fixes

### DIFF
--- a/modules/zmq/Makefile.am
+++ b/modules/zmq/Makefile.am
@@ -12,10 +12,9 @@ modules_zmq_libzmq_la_CFLAGS = \
 modules_zmq_libzmq_la_SOURCES = \
     modules/zmq/zmq-grammar.y \
     modules/zmq/zmq-plugin.c \
-    modules/zmq/zmq-destination.c \
-    modules/zmq/zmq-destination.h \
+    modules/zmq/zmq-module.h \
     modules/zmq/zmq-source.c \
-    modules/zmq/zmq-source.h \
+    modules/zmq/zmq-destination.c \
     modules/zmq/zmq-parser.c \
     modules/zmq/zmq-parser.h \
     modules/zmq/zmq-transport.c \

--- a/modules/zmq/zmq-destination.c
+++ b/modules/zmq/zmq-destination.c
@@ -139,7 +139,6 @@ static worker_insert_result_t
 zmq_worker_insert(LogThrDestDriver *destination, LogMessage *msg)
 {
   ZMQDestDriver *self = (ZMQDestDriver *)destination;
-  gboolean success = TRUE;
   GString *result = g_string_new("");
 
   if (self->socket == NULL)

--- a/modules/zmq/zmq-destination.c
+++ b/modules/zmq/zmq-destination.c
@@ -23,16 +23,7 @@
 
 #include <zmq.h>
 
-#include "zmq-destination.h"
-#include "zmq-parser.h"
-#include "plugin.h"
-#include "messages.h"
-#include "misc.h"
-#include "stats/stats.h"
-#include "logqueue.h"
-#include "driver.h"
-#include "plugin-types.h"
-#include "logthrdestdrv.h"
+#include "zmq-module.h"
 
 #ifndef SCS_ZMQ
 #define SCS_ZMQ 0

--- a/modules/zmq/zmq-module.h
+++ b/modules/zmq/zmq-module.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Laszlo Meszaros <lacienator@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef ZMQ_H_INCLUDED
+#define ZMQ_H_INCLUDED
+
+#define SCS_ZMQ 0
+
+#include "driver.h"
+#include "logreader.h"
+#include "logthrdestdrv.h"
+
+typedef struct _ZMQSourceDriver
+{
+  LogSrcDriver super;
+  LogReader* reader;
+  LogReaderOptions reader_options;
+
+  void* context;
+  void* socket;
+
+  gchar *address;
+  gint port;
+
+} ZMQSourceDriver;
+
+typedef struct _ZMQDestDriver
+{
+  LogThrDestDriver super;
+  gchar *port;
+  int socket_type;
+
+  GlobalConfig *cfg;
+
+  LogTemplateOptions template_options;
+  LogTemplate *template;
+
+  void *context;
+  void *socket;
+
+  gint32 seq_num;
+} ZMQDestDriver;
+
+LogDriver *zmq_sd_new(GlobalConfig *cfg);
+LogDriver *zmq_dd_new(GlobalConfig *cfg);
+
+void zmq_sd_set_address(LogDriver *source, const gchar *address);
+void zmq_sd_set_port(LogDriver *source, gint port);
+LogDriver *zmq_sd_new(GlobalConfig *cfg);
+
+void zmq_dd_set_port(LogDriver *destination, gint port);
+gboolean zmq_dd_set_socket_type(LogDriver *destination, gchar *socket_type);
+void zmq_dd_set_template(LogDriver *destination, gchar *template);
+LogTemplateOptions *zmq_dd_get_template_options(LogDriver *destination);
+
+#endif

--- a/modules/zmq/zmq-parser.h
+++ b/modules/zmq/zmq-parser.h
@@ -26,8 +26,7 @@
 
 #include "cfg-parser.h"
 #include "cfg-lexer.h"
-#include "zmq-destination.h"
-#include "zmq-source.h"
+#include "zmq-module.h"
 
 extern CfgParser zmq_parser;
 

--- a/modules/zmq/zmq-source.c
+++ b/modules/zmq/zmq-source.c
@@ -29,6 +29,8 @@
 #include "poll-fd-events.h"
 #include "logproto/logproto-text-server.h"
 
+void zmq_sd_set_address(LogDriver *source, const gchar *address);
+void zmq_sd_set_port(LogDriver *source, gint port);
 
 typedef struct _ZMQReaderContext
 {

--- a/modules/zmq/zmq-source.c
+++ b/modules/zmq/zmq-source.c
@@ -89,21 +89,23 @@ create_zmq_context(ZMQSourceDriver* self)
     return FALSE;
   }
 
-  if (zmq_bind(self->socket, get_address(self)) != 0)
+  gchar* address = get_address(self);
+
+  if (zmq_bind(self->socket, address) != 0)
   {
-    msg_error("Failed to bind!", evt_tag_str("Bind address", get_address(self)), evt_tag_errno("Error", errno),NULL);
+    msg_error("Failed to bind!", evt_tag_str("Bind address", address), evt_tag_errno("Error", errno),NULL);
+    g_free(address);
     return FALSE;
   }
 
+  g_free(address);
   return TRUE;
 }
 
 static inline gchar*
 get_persist_name(ZMQSourceDriver* self)
 {
-    gchar* persist_name;
-    persist_name = g_strdup_printf("zmq_source:%s:%d", self->address, self->port);
-    return persist_name;
+    return g_strdup_printf("zmq_source:%s:%d", self->address, self->port);
 }
 
 static gboolean
@@ -118,7 +120,11 @@ zmq_sd_init(LogPipe *s)
     return FALSE;
   }
 
-  ZMQReaderContext* reader_context = cfg_persist_config_fetch(cfg, get_persist_name(self));
+  gchar* persist_name = get_persist_name(self);
+
+  ZMQReaderContext* reader_context = cfg_persist_config_fetch(cfg, persist_name);
+
+  g_free(persist_name);
 
   log_reader_options_init(&self->reader_options, cfg, "zmq");
 
@@ -180,7 +186,11 @@ zmq_sd_deinit(LogPipe *s)
   self->context = NULL;
   self->reader = NULL;
 
-  cfg_persist_config_add(cfg, get_persist_name(self), reader_context, (GDestroyNotify) zmq_socket_deinit, FALSE);
+  gchar* persist_name = get_persist_name(self);
+
+  cfg_persist_config_add(cfg, persist_name, reader_context, (GDestroyNotify) zmq_socket_deinit, FALSE);
+
+  g_free(persist_name);
 
   return log_src_driver_deinit_method(s);
 }

--- a/modules/zmq/zmq-source.c
+++ b/modules/zmq/zmq-source.c
@@ -23,17 +23,9 @@
 
 #include <zmq.h>
 
-#include "zmq-source.h"
-#include "zmq-parser.h"
+#include "zmq-module.h"
 #include "zmq-transport.h"
 
-#include "plugin.h"
-#include "messages.h"
-#include "misc.h"
-#include "stats/stats.h"
-#include "logqueue.h"
-#include "driver.h"
-#include "plugin-types.h"
 #include "poll-fd-events.h"
 #include "logproto/logproto-text-server.h"
 

--- a/modules/zmq/zmq-transport.c
+++ b/modules/zmq/zmq-transport.c
@@ -31,7 +31,7 @@ typedef struct _LogTransportZMQ
 } LogTransportZMQ;
 
 static gssize
-log_transport_zmq_read_method(LogTransport *s, gpointer buf, gsize buflen, GSockAddr **sa)
+log_transport_zmq_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTransportAuxData *aux)
 {
   LogTransportZMQ *self = (LogTransportZMQ *) s;
   return zmq_recv(self->socket, buf, buflen, ZMQ_DONTWAIT);

--- a/modules/zmq/zmq-transport.h
+++ b/modules/zmq/zmq-transport.h
@@ -22,6 +22,6 @@
  */
 
 #include "transport/logtransport.h"
-#include "zmq-source.h"
+#include "zmq-module.h"
 
 LogTransport *log_transport_zmq_new(void* socket);


### PR DESCRIPTION
There were two warnings:
The first was because of the wrong signature of transport read method the first commit fix this.
The second was around zmq_sd_new(), unfortunatelly I couldn't fix this just only this way.
From now on source and destination have the same header file that contains the necessary structs and methods.
Please review these two patches and merge if it is okay