### PR TITLE
Fixes extraction on large groups

### DIFF
--- a/modules/getent/getent-group.c
+++ b/modules/getent/getent-group.c
@@ -38,9 +38,7 @@ tf_getent_group(gchar *key, gchar *member_name, GString *result)
   glong d;
   gboolean is_num, r;
 
-  bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
-  if (bufsize == -1)
-    bufsize = 16384;
+  bufsize = 16384;
 
   buf = g_malloc(bufsize);
 


### PR DESCRIPTION
    $(getent group) failed; key='124', errno='Numerical result out of range (34)'

A better fix maybe would be to reallocate
but according to @algernon this could be costly

http://www.spinics.net/lists/hotplug/msg02552.html