### PR TITLE
F/rust parsers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,8 @@ ACLOCAL_AMFLAGS		= -I m4
 AM_YFLAGS		= -Wno-other -d
 
 scldir			= ${datadir}/include/scl
+pkgconfigdir        = $(libdir)/pkgconfig
+pkgconfig_DATA      = syslog-ng-rust-deps.pc
 
 check_PROGRAMS		=
 TESTS			= ${check_PROGRAMS}

--- a/configure.ac
+++ b/configure.ac
@@ -90,6 +90,10 @@ AC_ARG_ENABLE(zmq,
 
 AC_ARG_ENABLE(date, [ --enable-date  Enable date parser (default: yes)],, enable_date="yes")
 
+AC_ARG_ENABLE(rust,
+              [  --enable-rust        Enable Rust bindings (default: auto)]
+              ,,enable_rust="auto")
+
 dnl ***************************************************************************
 dnl Checks for programs.
 AC_PROG_YACC
@@ -246,6 +250,9 @@ dnl ***************************************************************************
 
 INCUBATOR_CHECK_DEP(zmq,[PKG_CHECK_MODULES(ZMQ_CLIENT, libzmq >= $ZMQ_MIN_VERSION, zmq_found="yes", zmq_found="no")])
 
+if test "x$enable_rust" = "xyes" -o "x$enable_rust" = "xauto"; then
+    AC_CONFIG_FILES([syslog-ng-rust-deps.pc])
+fi
 dnl ***************************************************************************
 dnl create common cflags/libs for incubator modules.
 dnl ***************************************************************************
@@ -283,6 +290,7 @@ AM_CONDITIONAL(ENABLE_KAFKA, [test "x$enable_kafka" = "xyes"])
 AM_CONDITIONAL(ENABLE_ZMQ, [test "$enable_zmq" != "no"])
 AM_CONDITIONAL(ENABLE_GROK, [test "$enable_grok" != "no"])
 AM_CONDITIONAL(ENABLE_DATE, [test "$enable_date" = "yes"])
+AM_CONDITIONAL(ENABLE_RUST, [test "$enable_rust" = "yes"])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
@@ -304,4 +312,5 @@ echo "  tfgetent             yes"
 echo "  zmq                  ${enable_zmq:=no}"
 echo "  grok-parser          ${enable_grok}"
 echo "  date-parser          ${enable_date}"
+echo "  Rust bindings        ${enable_rust:=no}"
 echo

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -9,3 +9,4 @@ include modules/kafka/Makefile.am
 include modules/zmq/Makefile.am
 include modules/grok/Makefile.am
 include modules/date/Makefile.am
+include modules/rust/Makefile.am

--- a/modules/rust/Makefile.am
+++ b/modules/rust/Makefile.am
@@ -1,0 +1,34 @@
+if ENABLE_RUST
+
+export top_srcdir
+export top_builddir
+
+lib_LIBRARIES = modules/rust/libsyslog-ng-rust-deps.a
+modules_rust_libsyslog_ng_rust_deps_a_SOURCES = \
+  modules/rust/rust-grammar.y       \
+  modules/rust/rust-parser.c        \
+  modules/rust/rust-parser.h        \
+  modules/rust/parser.c				\
+  modules/rust/parser.h
+
+modules_rust_libsyslog_ng_rust_deps_a_CPPFLAGS = \
+  $(INCUBATOR_CFLAGS)	-fPIC		\
+  -I$(top_srcdir)/modules/rust        \
+  -I$(top_builddir)/modules/rust
+
+modules_rust_libsyslog_ng_rust_deps_a_LDFLAGS = -avoid-version -module -no-undefined
+
+else
+modules/rust modules/rust/ mod-rust: modules/rust/librust.la
+endif
+
+BUILT_SOURCES       +=      \
+  modules/rust/rust-grammar.y       \
+  modules/rust/rust-grammar.c       \
+  modules/rust/rust-grammar.h
+
+EXTRA_DIST        +=      \
+  modules/rust/rust-grammar.ym
+
+.PHONY: modules/rust/ mod-rust
+

--- a/modules/rust/Makefile.am
+++ b/modules/rust/Makefile.am
@@ -12,7 +12,8 @@ modules_rust_libsyslog_ng_rust_deps_a_SOURCES = \
   modules/rust/parser.h
 
 modules_rust_libsyslog_ng_rust_deps_a_CPPFLAGS = \
-  $(INCUBATOR_CFLAGS)	-fPIC		\
+  $(INCUBATOR_CFLAGS)	-fPIC	\
+  -fvisibility=hidden	\
   -I$(top_srcdir)/modules/rust        \
   -I$(top_builddir)/modules/rust
 

--- a/modules/rust/parser.c
+++ b/modules/rust/parser.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "parser.h"
+
+struct RustParserProxy;
+
+__attribute__((visibility("hidden"))) void
+rust_parser_proxy_free(struct RustParserProxy* this);
+
+__attribute__((visibility("hidden"))) void
+rust_parser_proxy_set_option(struct RustParserProxy* self, const gchar* key, const gchar* value);
+
+__attribute__((visibility("hidden"))) gboolean
+rust_parser_proxy_process(struct RustParserProxy* this, LogMessage *pmsg, const gchar *input, gsize input_len);
+
+__attribute__((visibility("hidden"))) int
+rust_parser_proxy_init(struct RustParserProxy* s);
+
+__attribute__((visibility("hidden"))) struct RustParserProxy*
+rust_parser_proxy_new(LogParser *super);
+
+__attribute__((visibility("hidden"))) struct RustParserProxy*
+rust_parser_proxy_clone(struct RustParserProxy *self);
+
+typedef struct _ParserRust {
+  LogParser super;
+  struct RustParserProxy* rust_object;
+} ParserRust;
+
+static LogPipe*
+rust_parser_clone(LogPipe *s);
+
+static gboolean
+rust_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input, gsize input_len)
+{
+  ParserRust *self = (ParserRust *) s;
+
+  LogMessage *writable_msg = log_msg_make_writable(pmsg, path_options);
+  return rust_parser_proxy_process(self->rust_object, writable_msg, input, input_len);
+}
+
+void
+rust_parser_set_option(LogParser *s, gchar* key, gchar* value)
+{    
+  ParserRust *self = (ParserRust *)s;
+
+  rust_parser_proxy_set_option(self->rust_object, key, value);
+}
+
+static gboolean
+rust_parser_init(LogPipe *s)
+{
+  ParserRust *self = (ParserRust *) s;
+
+  return !!rust_parser_proxy_init(self->rust_object);
+}
+
+static void
+rust_parser_free(LogPipe *s)
+{
+  ParserRust *self = (ParserRust *)s;
+
+  rust_parser_proxy_free(self->rust_object);
+  log_parser_free_method(s);
+}
+
+static void
+__setup_callback_methods(ParserRust *self)
+{
+  self->super.process = rust_parser_process;
+  self->super.super.free_fn = rust_parser_free;
+  self->super.super.clone = rust_parser_clone;
+  self->super.super.init = rust_parser_init;
+}
+
+static LogPipe*
+rust_parser_clone(LogPipe *s)
+{
+  ParserRust *self = (ParserRust*) s;
+  ParserRust *cloned;
+  
+  cloned = (ParserRust*) g_new0(ParserRust, 1);
+  log_parser_init_instance(&cloned->super, s->cfg);
+  cloned->rust_object = rust_parser_proxy_clone(self->rust_object);
+
+  if (!cloned->rust_object)
+    return NULL;
+
+  __setup_callback_methods(cloned);
+  
+  return &cloned->super.super; 
+}
+
+__attribute__((visibility("hidden"))) LogParser*
+rust_parser_new(GlobalConfig *cfg)
+{
+  ParserRust *self = (ParserRust*) g_new0(ParserRust, 1);
+
+  log_parser_init_instance(&self->super, cfg);
+  self->rust_object = rust_parser_proxy_new(&self->super);
+
+  if (!self->rust_object)
+    return NULL;
+
+  __setup_callback_methods(self);
+
+  return &self->super;
+}

--- a/modules/rust/parser.h
+++ b/modules/rust/parser.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef RUST_PARSER_H_INCLUDED
+#define RUST_PARSER_H_INCLUDED
+
+#include "parser/parser-expr.h"
+
+void rust_parser_set_option(LogParser *s, gchar* key, gchar* value);
+
+#endif

--- a/modules/rust/rust-grammar.ym
+++ b/modules/rust/rust-grammar.ym
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "rust-parser.h"
+
+}
+
+
+%code {
+
+#include "cfg-parser.h"
+#include "parser.h"
+#include "rust-grammar.h"
+#include "syslog-names.h"
+#include "messages.h"
+#include "plugin.h"
+#include "cfg-grammar.h"
+
+#include <string.h>
+
+}
+
+%name-prefix "rust_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogParser **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_OPTION
+
+%type <ptr> rust
+%type <ptr> rust_parser
+%type <ptr> rust_parser_params
+%%
+
+start
+  : rust
+    {
+      *instance = $1;
+      if (yychar != YYEMPTY)
+        cfg_lexer_unput_token(lexer, &yylval);
+      YYACCEPT;
+    }
+  ;
+
+rust
+  : LL_CONTEXT_PARSER rust_parser { $$ = $2; }
+  ;
+
+rust_parser
+  : LL_IDENTIFIER '(' rust_parser_params ')' { $$ = *instance; }
+  ;
+
+rust_parser_params
+  : {
+      *instance = rust_parser_new(configuration);
+
+      if (!*instance)
+       {
+         msg_error("Cannot create the Rust parser, aborting",
+                   NULL);
+         YYERROR;
+       }
+    }
+    rust_parser_options
+  ;
+
+rust_parser_options
+  : rust_parser_option rust_parser_options
+  |
+  ;
+
+rust_parser_option
+  : KW_OPTION '(' string string ')'
+    {
+      rust_parser_set_option(*instance, $3, $4);
+      free($3);
+      free($4);
+    }
+    ;
+
+/* INCLUDE_RULES */
+
+%%
+

--- a/modules/rust/rust-parser.c
+++ b/modules/rust/rust-parser.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-parser.h"
+#include "logpipe.h"
+#include "parser.h"
+#include "rust-grammar.h"
+
+extern int rust_debug;
+
+__attribute__((__visibility__("hidden"))) int rust_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
+
+static CfgLexerKeyword rust_keywords[] = {
+  { "option",   KW_OPTION },
+  { NULL }
+};
+ 
+__attribute__((__visibility__("hidden"))) CfgParser rust_parser =
+{
+#if ENABLE_DEBUG
+  .debug_flag = &rust_debug,
+#endif
+  .context = LL_IDENTIFIER,
+  .name = "rust-module",
+  .keywords = rust_keywords,
+  .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) rust_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(rust_, LogParser **)
+

--- a/modules/rust/rust-parser.h
+++ b/modules/rust/rust-parser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTER_RUST_PARSER_H_INCLUDED
+#define FILTER_RUST_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "cfg-lexer.h"
+#include "parser/parser-expr.h"
+
+CFG_PARSER_DECLARE_LEXER_BINDING(rust_, LogParser **)
+
+#endif
+

--- a/syslog-ng-rust-deps.pc.in
+++ b/syslog-ng-rust-deps.pc.in
@@ -1,0 +1,9 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+
+Name: libsyslog-ng-rust-deps
+Description: C dependencies for a syslog-ng Rust module
+Required: syslog-ng
+Version: 0.1.0
+Libs: -L${libdir} -lsyslog-ng-rust-deps


### PR DESCRIPTION
Implement Rust parser bindings.

This is just the C part and doesn't need `rustc` or other Rust related tools to be installed.

The Rust part is splitted into 3 crates (compilation units) and stored in the following git repo: https://github.com/ihrwein/syslog-ng-rs

That repo also needs a thorough review.