### PR TITLE
modules: use SYSLOG_NG_VERSION macro instead of VERSION

### DIFF
--- a/modules/basicfuncs-plus/basic-funcs-plus.c
+++ b/modules/basicfuncs-plus/basic-funcs-plus.c
@@ -55,7 +55,7 @@ basicfuncs_plus_module_init(GlobalConfig *cfg, CfgArgs *args)
 const ModuleInfo module_info =
 {
   .canonical_name = "basicfuncs-plus",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The basicfuncs-plus module provides some additional template functions for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = basicfuncs_plus_plugins,

--- a/modules/date/date-parser-plugin.c
+++ b/modules/date/date-parser-plugin.c
@@ -46,7 +46,7 @@ date_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 const ModuleInfo module_info =
 {
   .canonical_name = "date",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "Experimental date parser.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &date_plugin,

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -182,7 +182,7 @@ getent_plugin_module_init(GlobalConfig *cfg, CfgArgs *args)
 const ModuleInfo module_info =
 {
   .canonical_name = "getent-plugin",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The getent module provides getent template functions for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = getent_plugins,

--- a/modules/grok/grok-parser-plugin.c
+++ b/modules/grok/grok-parser-plugin.c
@@ -46,7 +46,7 @@ grok_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 const ModuleInfo module_info =
 {
   .canonical_name = "grok",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "Experimental grok parser.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &grok_plugin,

--- a/modules/kafka/kafka.c
+++ b/modules/kafka/kafka.c
@@ -538,7 +538,7 @@ kafka_module_init(GlobalConfig *cfg, CfgArgs *args)
 const ModuleInfo module_info =
 {
   .canonical_name = "kafka",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The afkafka module provides Kafka destination support for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &kafka_plugin,

--- a/modules/lua/lua-plugin.c
+++ b/modules/lua/lua-plugin.c
@@ -46,7 +46,7 @@ lua_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 const ModuleInfo module_info =
 {
   .canonical_name = "lua",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The lua module provides lua scripted destination support for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &lua_plugin,

--- a/modules/monitor-source/monitor-source-plugin.c
+++ b/modules/monitor-source/monitor-source-plugin.c
@@ -47,7 +47,7 @@ monitor_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 const ModuleInfo module_info =
 {
   .canonical_name = "monitor",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The monitor module provides stuff.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &monitor_plugin,

--- a/modules/perl/perl-plugin.c
+++ b/modules/perl/perl-plugin.c
@@ -55,7 +55,7 @@ perl_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 const ModuleInfo module_info =
 {
   .canonical_name = "perl",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The perl module provides Perl scripted destination support for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &perl_plugin,

--- a/modules/rss/rss.c
+++ b/modules/rss/rss.c
@@ -342,7 +342,7 @@ rss_module_init (GlobalConfig * cfg, CfgArgs * args)
 
 const ModuleInfo module_info = {
   .canonical_name = "rss",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The rss module is a destination driver to offer logs in RSS feed.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &rss_plugin,

--- a/modules/trigger-source/trigger-source-plugin.c
+++ b/modules/trigger-source/trigger-source-plugin.c
@@ -46,7 +46,7 @@ trigger_module_init(GlobalConfig *cfg, CfgArgs *args G_GNUC_UNUSED)
 const ModuleInfo module_info =
 {
   .canonical_name = "trigger",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The trigger module provides stuff.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = &trigger_plugin,

--- a/modules/zmq/zmq-plugin.c
+++ b/modules/zmq/zmq-plugin.c
@@ -58,7 +58,7 @@ zmq_module_init(GlobalConfig *cfg, CfgArgs *args)
 const ModuleInfo module_info =
 {
   .canonical_name = "zmq",
-  .version = VERSION,
+  .version = SYSLOG_NG_VERSION,
   .description = "The zmq module provides ZeroMQ destination support for syslog-ng.",
   .core_revision = "Dummy Revision",
   .plugins = zmq_plugins,


### PR DESCRIPTION
This PR updates the macros changed by https://github.com/balabit/syslog-ng/pull/782.

Signed-off-by: Tibor Benke ihrwein@gmail.com
