### PR TITLE
kafka: fix queue.buffering.max.ms value in example

### DIFF
--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -21,7 +21,7 @@ destination d_kafka {
     };
     destination {
       kafka(properties(metadata.broker.list("localhost:9092")
-                       queue.buffering.max.ms("1"))
+                       queue.buffering.max.ms("1000"))
             topic("syslog-ng")
             payload("$(format-json --key .eventv1.* --rekey .eventv1.* --shift 9)"));
     };


### PR DESCRIPTION
Setting a too low value incurs a moderate CPU usage even when no logs
need to be forwarded. Increase the value to 1s instead.

Signed-off-by: Vincent Bernat <vincent@bernat.im>