### PR TITLE
#include "misc.h" for init_sequence_number

### DIFF
--- a/modules/zmq/zmq-destination.c
+++ b/modules/zmq/zmq-destination.c
@@ -24,6 +24,7 @@
 #include <zmq.h>
 
 #include "zmq-module.h"
+#include "misc.h"
 
 #ifndef SCS_ZMQ
 #define SCS_ZMQ 0


### PR DESCRIPTION
the zmq destination need init_sequence_number. So we have to include "misc.h".  Otherwise it crash when running.

Signed-off-by: Yilin Li <liyilin1214@gmail.com>